### PR TITLE
Add MP stat for monsters

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,8 +20,9 @@ def get_monster_instance_copy(monster_id_or_object: Monster | str) -> Monster | 
             # ALL_MONSTERSのテンプレートから新しいインスタンスをコピー
             new_monster = ALL_MONSTERS[monster_id].copy()
             if new_monster:
-                # 戦闘や仲間にする際の初期状態（HP最大など）
+                # 戦闘や仲間にする際の初期状態（HP/MP最大など）
                 new_monster.hp = new_monster.max_hp
+                new_monster.mp = new_monster.max_mp
                 new_monster.is_alive = True
             return new_monster
         else:
@@ -32,6 +33,7 @@ def get_monster_instance_copy(monster_id_or_object: Monster | str) -> Monster | 
         new_monster = monster_id_or_object.copy()
         if new_monster:
             new_monster.hp = new_monster.max_hp # HPを最大にリセット
+            new_monster.mp = new_monster.max_mp
             new_monster.is_alive = True
         return new_monster
     else:

--- a/monsters/monster_class.py
+++ b/monsters/monster_class.py
@@ -84,12 +84,14 @@ def calculate_exp_for_late(current_level):
         raise
 
 class Monster:
-    def __init__(self, name, hp, attack, defense, level=1, exp=0, element=None, skills=None,
+    def __init__(self, name, hp, attack, defense, mp=0, level=1, exp=0, element=None, skills=None,
                  growth_type=GROWTH_TYPE_AVERAGE, monster_id=None, image_filename=None,
                  rank=RANK_D, speed=5, drop_items=None):
         self.name = name
         self.hp = hp
         self.max_hp = hp
+        self.mp = mp
+        self.max_mp = mp
         self.attack = attack
         self.defense = defense
         self.level = level
@@ -115,6 +117,7 @@ class Monster:
         if self.element:
             print(f"属性: {self.element}")
         print(f"HP: {self.hp}/{self.max_hp}")
+        print(f"MP: {self.mp}/{self.max_mp}")
         print(f"攻撃力: {self.attack}")
         print(f"防御力: {self.defense}")
         print(f"素早さ: {self.speed}") # 素早さを表示
@@ -194,16 +197,21 @@ class Monster:
                 status_gains_dict = {"hp": 1, "attack": 1, "defense": 1} 
 
             hp_increase = status_gains_dict.get("hp", 0)
+            mp_increase = status_gains_dict.get("mp", 0)
             attack_increase = status_gains_dict.get("attack", 0)
             defense_increase = status_gains_dict.get("defense", 0)
             # TODO: speed の上昇ロジックもここに追加する
                 
             self.max_hp += hp_increase
-            self.hp = self.max_hp 
+            self.hp = self.max_hp
+            self.max_mp += mp_increase
+            self.mp = self.max_mp
             self.attack += attack_increase
             self.defense += defense_increase
 
-            print(f"最大HPが {hp_increase}、攻撃力が {attack_increase}、防御力が {defense_increase} 上昇した！")
+            print(
+                f"最大HPが {hp_increase}、MPが {mp_increase}、攻撃力が {attack_increase}、防御力が {defense_increase} 上昇した！"
+            )
         except Exception as e:
             raise 
 
@@ -213,11 +221,12 @@ class Monster:
             
             new_monster = Monster(
                 name=self.name,
-                hp=self.max_hp, 
+                hp=self.max_hp,
                 attack=self.attack,
                 defense=self.defense,
-                level=self.level, 
-                exp=self.exp,    
+                mp=self.max_mp,
+                level=self.level,
+                exp=self.exp,
                 element=self.element,
                 skills=new_skills,
                 growth_type=self.growth_type,
@@ -227,9 +236,11 @@ class Monster:
                 speed=self.speed,  # speed 属性をコピー時に引き継ぐ
                 drop_items=copy.deepcopy(self.drop_items)
             )
-            new_monster.max_hp = self.max_hp 
-            new_monster.hp = new_monster.max_hp 
-            new_monster.is_alive = True 
+            new_monster.max_hp = self.max_hp
+            new_monster.hp = new_monster.max_hp
+            new_monster.max_mp = self.max_mp
+            new_monster.mp = new_monster.max_mp
+            new_monster.is_alive = True
             return new_monster
         except Exception as e:
-            raise 
+            raise

--- a/monsters/monster_data.py
+++ b/monsters/monster_data.py
@@ -12,7 +12,7 @@ RANK_C = "C"
 RANK_D = "D"
 
 SLIME = Monster(
-    name="スライム", hp=25, attack=8, defense=5, level=1, element="水",
+    name="スライム", hp=25, attack=8, defense=5, mp=10, level=1, element="水",
     skills=[ALL_SKILLS["heal"]] if "heal" in ALL_SKILLS else [],
     growth_type=GROWTH_TYPE_EARLY,
     monster_id="slime",
@@ -21,7 +21,7 @@ SLIME = Monster(
 )
 
 GOBLIN = Monster(
-    name="ゴブリン", hp=40, attack=12, defense=8, level=2, element="なし",
+    name="ゴブリン", hp=40, attack=12, defense=8, mp=5, level=2, element="なし",
     skills=[ALL_SKILLS["fireball"]] if "fireball" in ALL_SKILLS else [],
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="goblin",
@@ -30,7 +30,7 @@ GOBLIN = Monster(
 )
 
 WOLF = Monster(
-    name="ウルフ", hp=50, attack=15, defense=7, level=3, element="なし",
+    name="ウルフ", hp=50, attack=15, defense=7, mp=5, level=3, element="なし",
     skills=[],
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="wolf",
@@ -43,6 +43,7 @@ SLIME_GOBLIN_HYBRID = Monster(
     hp=35,
     attack=10,
     defense=7,
+    mp=12,
     level=1, 
     element="混合",
     skills=[], 
@@ -58,6 +59,7 @@ DRAGON_PUP = Monster(
     hp=70,
     attack=25,
     defense=20,
+    mp=15,
     level=5,
     element="火",
     skills=[ALL_SKILLS["fireball"]] if "fireball" in ALL_SKILLS else [], # 初期スキルは弱めでも良い
@@ -72,6 +74,7 @@ PHOENIX_CHICK = Monster(
     hp=60,
     attack=18,
     defense=22,
+    mp=20,
     level=5,
     element="火",
     skills=[ALL_SKILLS["heal"]] if "heal" in ALL_SKILLS else [], # 自己回復スキル持ち

--- a/player.py
+++ b/player.py
@@ -76,6 +76,7 @@ class Player:
                 new_monster_instance.level = 1 # またはALL_MONSTERS[monster_id_key].level
                 new_monster_instance.exp = 0
                 new_monster_instance.hp = new_monster_instance.max_hp # HPは最大に
+                new_monster_instance.mp = new_monster_instance.max_mp
                 
                 self.party_monsters.append(new_monster_instance)
                 print(f"{new_monster_instance.name} が仲間に加わった！")
@@ -90,7 +91,8 @@ class Player:
                 print(f"エラー: モンスターオブジェクト '{monster_object.name}' のコピーに失敗しました。")
                 return
 
-            self.party_monsters.append(copied_monster) 
+            copied_monster.mp = copied_monster.max_mp
+            self.party_monsters.append(copied_monster)
             print(f"{copied_monster.name} が仲間に加わった！")
             newly_added_monster = copied_monster
         else:
@@ -129,6 +131,7 @@ class Player:
             print(f"{cost}G を支払い、宿屋に泊まった。")
             for monster in self.party_monsters:
                 monster.hp = monster.max_hp
+                monster.mp = monster.max_mp
                 monster.is_alive = True
             print("パーティは完全に回復した！")
             return True
@@ -191,6 +194,7 @@ class Player:
                 new_monster.level = 1
                 new_monster.exp = 0
                 new_monster.hp = new_monster.max_hp # HPは最大に
+                new_monster.mp = new_monster.max_mp
                 new_monster.is_alive = True
                 # print(f"[DEBUG player.py synthesize_monster] Newly synthesized monster: name='{new_monster.name}', monster_id='{new_monster.monster_id}'")
                 


### PR DESCRIPTION
## Summary
- introduce MP (magic points) to the `Monster` class
- track MP in monster leveling and copying logic
- recover MP when resting at an inn
- populate MP values for predefined monsters
- keep HP/MP at max when instantiating monsters

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f93bfc6048321b495016181f6b23a