### PR TITLE
Implement exploration progress and hidden boss

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,7 +85,8 @@ def game_loop(hero: Player): # 型ヒントを追加
         print("1: 移動する")
         print("2: ステータス確認 (主人公)")
         print("3: パーティ確認 (モンスター)")
-        print("4: モンスター合成") 
+        print("4: モンスター合成")
+        print("5: 探索する")
         
         if hasattr(current_location_data, 'has_inn') and current_location_data.has_inn:
             inn_cost = current_location_data.inn_cost if hasattr(current_location_data, 'inn_cost') else 10
@@ -216,6 +217,31 @@ def game_loop(hero: Player): # 型ヒントを追加
                 print(f"入力エラー: {e}")
             except Exception as e:
                 print(f"合成中に予期せぬエラーが発生しました: {e}")
+
+        elif action == "5":  # 探索する
+            progress_before = hero.get_exploration(hero.current_location_id)
+            gained = random.randint(15, 30)
+            progress_after = hero.increase_exploration(hero.current_location_id, gained)
+            print(f"探索を行った。探索率が {progress_after}% になった。")
+            if progress_before < 100 <= progress_after:
+                if getattr(current_location_data, 'hidden_connections', {}):
+                    current_location_data.connections.update(current_location_data.hidden_connections)
+                    print("新たな道が開けた！")
+
+            if current_location_data.possible_enemies and random.random() < current_location_data.encounter_rate:
+                print("\n!!!モンスターが襲ってきた!!!")
+                player_battle_party = hero.party_monsters
+                enemy_battle_party = generate_enemy_party(current_location_data)
+                if enemy_battle_party:
+                    battle_outcome_result_str = start_battle(player_battle_party, enemy_battle_party, hero)
+                    if battle_outcome_result_str == "win":
+                        print(f"{hero.name} は勝利した！")
+                    elif battle_outcome_result_str == "lose":
+                        print(f"{hero.name} は敗北してしまった...")
+                    elif battle_outcome_result_str == "fled":
+                        print(f"{hero.name} は戦闘から逃げ出した。")
+                else:
+                    print("敵は現れなかった...")
         
         elif action == "8": # 宿屋
             if hasattr(current_location_data, 'has_inn') and current_location_data.has_inn:

--- a/map_data.py
+++ b/map_data.py
@@ -2,7 +2,7 @@
 import random # エンカウント判定で使います
 
 class Location:
-    def __init__(self, location_id, name, description, connections=None, possible_enemies=None, encounter_rate=0.0, has_inn=False, inn_cost=0):
+    def __init__(self, location_id, name, description, connections=None, possible_enemies=None, encounter_rate=0.0, has_inn=False, inn_cost=0, hidden_connections=None):
         """
         場所の情報を保持するクラス。
         location_id (str): 場所を識別するユニークなID
@@ -22,6 +22,7 @@ class Location:
         self.encounter_rate = encounter_rate
         self.has_inn = has_inn  # 宿屋があるかどうかのフラグ (True/False)
         self.inn_cost = inn_cost  # 宿泊料金**
+        self.hidden_connections = hidden_connections if hidden_connections else {}
 
     def get_random_enemy_id(self):
         """この場所で出現する可能性のあるモンスターIDをランダムに1つ返す。"""
@@ -63,7 +64,16 @@ LOCATIONS = {
         description="木々が鬱蒼と茂り、昼なお暗い。強力なモンスターが生息しているようだ。",
         connections={"入り口へ": "forest_entrance"},
         possible_enemies=["wolf", "goblin"], # wolf は ALL_MONSTERS に定義が必要
-        encounter_rate=0.9
+        encounter_rate=0.9,
+        hidden_connections={"さらに奥へ": "forest_boss_room"}
+    ),
+    "forest_boss_room": Location(
+        location_id="forest_boss_room",
+        name="森の守護者の間",
+        description="森の奥深くに佇む神秘的な祭壇。強大なモンスターの気配がする。",
+        connections={"奥地へ戻る": "deep_forest"},
+        possible_enemies=["dragon_pup"],
+        encounter_rate=1.0
     ),
     
 }

--- a/player.py
+++ b/player.py
@@ -20,6 +20,7 @@ class Player:
         self.items = []
         self.current_location_id = STARTING_LOCATION_ID
         self.db_id = None # データベース上のID (ロード時に設定)
+        self.exploration_progress = {}
 
     def save_game(self, db_name):
         conn = sqlite3.connect(db_name)
@@ -73,6 +74,15 @@ class Player:
         else:
             print("  (まだ仲間モンスターがいません)")
         print("=" * 26)
+
+    def get_exploration(self, location_id):
+        return self.exploration_progress.get(location_id, 0)
+
+    def increase_exploration(self, location_id, amount):
+        current = self.exploration_progress.get(location_id, 0)
+        new_value = min(100, current + amount)
+        self.exploration_progress[location_id] = new_value
+        return new_value
 
     def add_monster_to_party(self, monster_id_or_object):
         """


### PR DESCRIPTION
## Summary
- track exploration progress per location in `Player`
- extend `Location` with optional `hidden_connections`
- add new boss area to `map_data`
- add an "explore" option in game loop to increment exploration and reveal hidden paths

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fa29adc84832188674480a710b271