### PR TITLE
Implement monster scout mechanic

### DIFF
--- a/battle.py
+++ b/battle.py
@@ -96,6 +96,27 @@ def is_party_defeated(party: list[Monster]) -> bool:
     """パーティが全滅したかどうかを判定します。"""
     return all(not monster.is_alive for monster in party)
 
+def attempt_scout(player: Player, target: Monster, enemy_party: list[Monster]) -> bool:
+    """敵モンスターをスカウトして仲間にする試みを行う。成功するとTrueを返す。"""
+    if target is None or not target.is_alive:
+        print("対象がいません。")
+        return False
+
+    rate = getattr(target, "scout_rate", 0.25)
+    print(f"\n{target.name} をスカウトしている...")
+
+    if random.random() < rate:
+        print(f"{target.name} は仲間になりたそうにこちらを見ている！")
+        if player is not None:
+            player.add_monster_to_party(target)
+        target.is_alive = False
+        if target in enemy_party:
+            enemy_party.remove(target)
+        return True
+    else:
+        print(f"{target.name} は警戒している。仲間にならなかった。")
+        return False
+
 def start_battle(player_party: list[Monster], enemy_party: list[Monster], player: Player | None = None):
     """
     3vs3の戦闘を開始します。
@@ -149,8 +170,9 @@ def start_battle(player_party: list[Monster], enemy_party: list[Monster], player
                 print(f"\n>>> {actor.name} の行動！ <<<")
                 print("1: たたかう")
                 print("2: スキル")
-                print("3: にげる")
-                action_choice = get_player_choice("行動を選んでください", 3)
+                print("3: スカウト")
+                print("4: にげる")
+                action_choice = get_player_choice("行動を選んでください", 4)
 
                 if action_choice == 1:  # たたかう
                     target = select_target(active_enemy_party, "\n攻撃対象を選んでください:")
@@ -200,7 +222,16 @@ def start_battle(player_party: list[Monster], enemy_party: list[Monster], player
                         print(f"{selected_skill.name} は適切な対象に使えなかった。")
                         continue
 
-                elif action_choice == 3:  # にげる
+                elif action_choice == 3:  # スカウト
+                    target = select_target(active_enemy_party, "\nスカウトする対象を選んでください:")
+                    if target:
+                        attempt_scout(player, target, enemy_party)
+                        if not target.is_alive and target in active_enemy_party:
+                            active_enemy_party.remove(target)
+                    else:
+                        print("スカウトをキャンセルしました。")
+
+                elif action_choice == 4:  # にげる
                     print(f"\n{actor.name} は逃げ出そうとした！")
                     if random.random() < 0.5:
                         print("うまく逃げ切れた！")

--- a/monsters/monster_class.py
+++ b/monsters/monster_class.py
@@ -86,7 +86,7 @@ def calculate_exp_for_late(current_level):
 class Monster:
     def __init__(self, name, hp, attack, defense, level=1, exp=0, element=None, skills=None,
                  growth_type=GROWTH_TYPE_AVERAGE, monster_id=None, image_filename=None,
-                 rank=RANK_D, speed=5, drop_items=None):
+                 rank=RANK_D, speed=5, drop_items=None, scout_rate=0.25):
         self.name = name
         self.hp = hp
         self.max_hp = hp
@@ -109,6 +109,7 @@ class Monster:
         self.rank = rank 
         self.speed = speed  # speed 属性を保存
         self.drop_items = drop_items if drop_items else []
+        self.scout_rate = scout_rate  # スカウト成功率(0.0-1.0)
 
     def show_status(self):
         print(f"名前: {self.name} (ID: {self.monster_id}, Lv.{self.level}, Rank: {self.rank})") 
@@ -225,7 +226,8 @@ class Monster:
                 image_filename=self.image_filename,
                 rank=self.rank,
                 speed=self.speed,  # speed 属性をコピー時に引き継ぐ
-                drop_items=copy.deepcopy(self.drop_items)
+                drop_items=copy.deepcopy(self.drop_items),
+                scout_rate=self.scout_rate
             )
             new_monster.max_hp = self.max_hp 
             new_monster.hp = new_monster.max_hp 

--- a/monsters/monster_data.py
+++ b/monsters/monster_data.py
@@ -17,7 +17,8 @@ SLIME = Monster(
     growth_type=GROWTH_TYPE_EARLY,
     monster_id="slime",
     rank=RANK_D,
-    drop_items=[(ALL_ITEMS["small_potion"], 0.2)]
+    drop_items=[(ALL_ITEMS["small_potion"], 0.2)],
+    scout_rate=0.5
 )
 
 GOBLIN = Monster(
@@ -26,7 +27,8 @@ GOBLIN = Monster(
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="goblin",
     rank=RANK_D,
-    drop_items=[(ALL_ITEMS["small_potion"], 0.15)]
+    drop_items=[(ALL_ITEMS["small_potion"], 0.15)],
+    scout_rate=0.4
 )
 
 WOLF = Monster(
@@ -35,7 +37,8 @@ WOLF = Monster(
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="wolf",
     rank=RANK_C,
-    drop_items=[(ALL_ITEMS["small_potion"], 0.1)]
+    drop_items=[(ALL_ITEMS["small_potion"], 0.1)],
+    scout_rate=0.35
 )
 
 SLIME_GOBLIN_HYBRID = Monster(
@@ -43,13 +46,14 @@ SLIME_GOBLIN_HYBRID = Monster(
     hp=35,
     attack=10,
     defense=7,
-    level=1, 
+    level=1,
     element="混合",
-    skills=[], 
+    skills=[],
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="slime_goblin_hybrid",
     rank=RANK_C,
-    drop_items=[(ALL_ITEMS["small_potion"], 0.25)]  # 例: 合成モンスターはCランク
+    drop_items=[(ALL_ITEMS["small_potion"], 0.25)],  # 例: 合成モンスターはCランク
+    scout_rate=0.3
 )
 
 # 例として高ランクモンスターを追加
@@ -64,7 +68,8 @@ DRAGON_PUP = Monster(
     growth_type=GROWTH_TYPE_LATE, # 大器晩成型
     monster_id="dragon_pup",
     rank=RANK_A,
-    drop_items=[(ALL_ITEMS["small_potion"], 0.05)]
+    drop_items=[(ALL_ITEMS["small_potion"], 0.05)],
+    scout_rate=0.15
 )
 
 PHOENIX_CHICK = Monster(
@@ -78,7 +83,8 @@ PHOENIX_CHICK = Monster(
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="phoenix_chick",
     rank=RANK_S,
-    drop_items=[(ALL_ITEMS["small_potion"], 0.05)]  # 例: 不死鳥のヒナはSランク
+    drop_items=[(ALL_ITEMS["small_potion"], 0.05)],  # 例: 不死鳥のヒナはSランク
+    scout_rate=0.1
 )
 
 


### PR DESCRIPTION
## Summary
- enable recruiting monsters with a scout action
- add `scout_rate` attribute to monsters
- show new scout option during battle
- define scout success rates for each monster template

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa7be37708321abc89d7c6301603c