### PR TITLE
Add extra monsters and map

### DIFF
--- a/map_data.py
+++ b/map_data.py
@@ -60,16 +60,24 @@ LOCATIONS = {
         location_id="forest_entrance",
         name="妖精の森・入り口",
         description="薄暗い森の入り口。奥からはかすかに獣の気配がする。",
-        connections={"南西": "field_near_village", "奥へ": "deep_forest"},
+        connections={"南西": "field_near_village", "奥へ": "deep_forest", "東": "mystic_lake"},
         possible_enemies=["goblin", "slime"],
         encounter_rate=0.75
+    ),
+    "mystic_lake": Location(
+        location_id="mystic_lake",
+        name="神秘の湖",
+        description="森の奥にひっそりと佇む美しい湖。水面が青く光っている。",
+        connections={"西": "forest_entrance"},
+        possible_enemies=["water_wolf", "forest_spirit"],
+        encounter_rate=0.8
     ),
     "deep_forest": Location(
         location_id="deep_forest",
         name="妖精の森・奥地",
         description="木々が鬱蒼と茂り、昼なお暗い。強力なモンスターが生息しているようだ。",
         connections={"入り口へ": "forest_entrance"},
-        possible_enemies=["wolf", "goblin"], # wolf は ALL_MONSTERS に定義が必要
+        possible_enemies=["wolf", "goblin", "forest_spirit"],
         encounter_rate=0.9,
         hidden_connections={"さらに奥へ": "forest_boss_room"}
     ),

--- a/monsters/monster_data.py
+++ b/monsters/monster_data.py
@@ -87,6 +87,37 @@ PHOENIX_CHICK = Monster(
     scout_rate=0.1
 )
 
+# 新しいモンスター
+WATER_WOLF = Monster(
+    name="ウォーターウルフ",
+    hp=60,
+    attack=20,
+    defense=12,
+    level=3,
+    element="水",
+    skills=[ALL_SKILLS["heal"]] if "heal" in ALL_SKILLS else [],
+    growth_type=GROWTH_TYPE_AVERAGE,
+    monster_id="water_wolf",
+    rank=RANK_C,
+    drop_items=[(ALL_ITEMS["small_potion"], 0.1)],
+    scout_rate=0.3
+)
+
+FOREST_SPIRIT = Monster(
+    name="森の精霊",
+    hp=55,
+    attack=17,
+    defense=15,
+    level=4,
+    element="風",
+    skills=[ALL_SKILLS["guard_up"]] if "guard_up" in ALL_SKILLS else [],
+    growth_type=GROWTH_TYPE_EARLY,
+    monster_id="forest_spirit",
+    rank=RANK_B,
+    drop_items=[(ALL_ITEMS["small_potion"], 0.2)],
+    scout_rate=0.25
+)
+
 
 ALL_MONSTERS = {
     "slime": SLIME,
@@ -95,4 +126,6 @@ ALL_MONSTERS = {
     "slime_goblin_hybrid": SLIME_GOBLIN_HYBRID,
     "dragon_pup": DRAGON_PUP,
     "phoenix_chick": PHOENIX_CHICK,
+    "water_wolf": WATER_WOLF,
+    "forest_spirit": FOREST_SPIRIT,
 }

--- a/synthesis_rules.py
+++ b/synthesis_rules.py
@@ -7,8 +7,8 @@
 
 SYNTHESIS_RECIPES = {
     ("goblin", "slime"): "slime_goblin_hybrid", # ゴブリンとスライムを合成するとスライムゴブリンハイブリッドが生まれる
+    ("slime", "wolf"): "water_wolf",
     # 他のレシピもここに追加
-    # 例: ("slime", "wolf"): "water_wolf",
 }
 
 # 将来的には、合成に必要なアイテムなどもここに定義できる


### PR DESCRIPTION
## Summary
- add Water Wolf and Forest Spirit monsters
- allow fusing Slime and Wolf to create Water Wolf
- add Mystic Lake location and update forest areas with new monster spawns

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faf21cafc8321999b0fccd5054523