### PR TITLE
Enable selectable and party healing skills

### DIFF
--- a/skills/skills.py
+++ b/skills/skills.py
@@ -1,5 +1,5 @@
 class Skill:
-    def __init__(self, name, power, cost=0, skill_type="attack", effect=None, target="enemy"):
+    def __init__(self, name, power, cost=0, skill_type="attack", effect=None, target="enemy", scope="single"):
         """
         :param name: スキル名
         :param power: 威力（攻撃なら攻撃力に加算、回復なら回復量）
@@ -7,6 +7,7 @@ class Skill:
         :param skill_type: "attack", "heal", "buff", "debuff", "status"
         :param effect: 特殊効果（関数や状態異常名など）
         :param target: "enemy" or "ally"（対象指定）
+        :param scope: "single" or "all"（単体か全体か）
         """
         self.name = name
         self.power = power
@@ -14,14 +15,17 @@ class Skill:
         self.skill_type = skill_type
         self.effect = effect
         self.target = target
+        self.scope = scope
 
     def describe(self):
-        return f"{self.name} (Type: {self.skill_type}, Power: {self.power})"
+        scope_text = "全体" if self.scope == "all" else "単体"
+        return f"{self.name} (Type: {self.skill_type}, Power: {self.power}, {scope_text})"
 # 攻撃スキル
 fireball = Skill("ファイアボール", power=30, skill_type="attack", effect="burn")
 
 # 回復スキル
 heal = Skill("ヒール", power=25, skill_type="heal", target="ally")
+mass_heal = Skill("ヒールオール", power=15, skill_type="heal", target="ally", scope="all")
 
 # バフスキル
 def increase_defense(monster):
@@ -33,6 +37,7 @@ ALL_SKILLS = {
     "fireball": fireball,
     "heal": heal,
     "guard_up": guard_up,
+    "mass_heal": mass_heal,
     # 新しいスキルを追加したら、ここにも追記していきます
     # "thunder_bolt": thunder_bolt, # 例えば
 }


### PR DESCRIPTION
## Summary
- allow `Skill` to specify single or all target scope
- add `mass_heal` skill
- update battle logic so healing skills can target chosen allies or heal the whole party

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb3a2ba708321813089995ee808b5