### PR TITLE
Implement battle loss handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,6 +103,30 @@ def open_shop(player: Player, location: Location):
             print("無効な選択です。")
 
 
+def handle_battle_loss(hero: Player) -> str:
+    """Handle menu flow after the player loses a battle.
+
+    Returns one of "retry", "load", or "exit" depending on the player's choice.
+    """
+    while True:
+        print("\n--- GAME OVER ---")
+        print("1: リトライする")
+        print("2: セーブデータをロードする")
+        print("3: ゲームを終了する")
+        choice = input("選択: ").strip()
+        if choice == "1":
+            return "retry"
+        elif choice == "2":
+            loaded = Player.load_game(DATABASE_NAME)
+            if loaded:
+                hero.__dict__.update(loaded.__dict__)
+            return "load"
+        elif choice == "3":
+            return "exit"
+        else:
+            print("無効な選択です。")
+
+
 def game_loop(hero: Player): # 型ヒントを追加
     """ゲームのメインループ"""
     game_over = False
@@ -201,7 +225,9 @@ def game_loop(hero: Player): # 型ヒントを追加
                             # 経験値やアイテム獲得はbattle.py内で処理済み（player_battle_partyの要素が更新される）
                         elif battle_outcome_result_str == "lose":
                             print(f"{hero.name} は敗北してしまった...")
-                            # TODO: ゲームオーバー処理など
+                            result = handle_battle_loss(hero)
+                            if result == "exit":
+                                game_over = True
                         elif battle_outcome_result_str == "fled":
                             print(f"{hero.name} は戦闘から逃げ出した。")
                         else: # draw や予期せぬ結果
@@ -282,6 +308,10 @@ def game_loop(hero: Player): # 型ヒントを追加
                         print(f"{hero.name} は勝利した！")
                     elif battle_outcome_result_str == "lose":
                         print(f"{hero.name} は敗北してしまった...")
+                        res = handle_battle_loss(hero)
+                        if res == "exit":
+                            game_over = True
+                            break
                     elif battle_outcome_result_str == "fled":
                         print(f"{hero.name} は戦闘から逃げ出した。")
                 else:

--- a/tests/test_battle_loss_flow.py
+++ b/tests/test_battle_loss_flow.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import main
+from player import Player
+from monsters.monster_data import ALL_MONSTERS
+
+class BattleLossFlowTest(unittest.TestCase):
+    def setUp(self):
+        self.hero = Player('Tester')
+        self.hero.add_monster_to_party('slime')
+        self.hero.current_location_id = 'village_square'
+
+    def test_loss_triggers_handler(self):
+        inputs = ['1', '1']
+        with patch('main.start_battle', return_value='lose'), \
+             patch('main.handle_battle_loss', return_value='exit') as mock_handler, \
+             patch('main.random.random', return_value=0.0), \
+             patch('builtins.input', side_effect=inputs):
+            main.game_loop(self.hero)
+            self.assertTrue(mock_handler.called)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `handle_battle_loss` helper
- invoke the new helper when the player loses a fight
- test that losing a battle triggers the handler

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840176a8de883218de84ba712961890