### PR TITLE
Add speed gains handling

### DIFF
--- a/monsters/monster_class.py
+++ b/monsters/monster_class.py
@@ -213,12 +213,17 @@ class Monster:
                 status_gains_dict = get_status_gains_average(self.level)
             
             if not isinstance(status_gains_dict, dict):
-                status_gains_dict = {"hp": 1, "attack": 1, "defense": 1, "speed": 1}
+                status_gains_dict = {}
 
-            hp_increase = status_gains_dict.get("hp", 0)
-            attack_increase = status_gains_dict.get("attack", 0)
-            defense_increase = status_gains_dict.get("defense", 0)
-            speed_increase = status_gains_dict.get("speed", 0)
+            status_gains_dict.setdefault("hp", 0)
+            status_gains_dict.setdefault("attack", 0)
+            status_gains_dict.setdefault("defense", 0)
+            status_gains_dict.setdefault("speed", 0)
+
+            hp_increase = status_gains_dict["hp"]
+            attack_increase = status_gains_dict["attack"]
+            defense_increase = status_gains_dict["defense"]
+            speed_increase = status_gains_dict["speed"]
                 
             self.max_hp += hp_increase
             self.hp = self.max_hp 

--- a/tests/test_level_up.py
+++ b/tests/test_level_up.py
@@ -17,8 +17,10 @@ class LevelUpSpeedTests(unittest.TestCase):
         with redirect_stdout(buf):
             monster.level_up()
         output = buf.getvalue()
-        self.assertIn("素早さが", output)
-        self.assertGreater(monster.speed, start_speed)
+        end_speed = monster.speed
+        speed_gain = end_speed - start_speed
+        self.assertIn(f"素早さが {speed_gain}", output)
+        self.assertGreater(end_speed, start_speed)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle missing speed key in `level_up`
- check numeric speed gain in level-up test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402853b18c8321b70cf5be32880f21