### PR TITLE
Add synthesis item requirements

### DIFF
--- a/items/item_data.py
+++ b/items/item_data.py
@@ -1,3 +1,15 @@
+# Item definitions
+
+class Item:
+    def __init__(self, item_id, name, description, usable=False):
+        self.item_id = item_id
+        self.name = name
+        self.description = description
+        self.usable = usable
+
+    def __repr__(self):
+        return f"Item({self.item_id})"
+
 # ── 回復系・サポート系 ───────────────────────────────
 small_potion = Item(
     item_id="small_potion",

--- a/player.py
+++ b/player.py
@@ -4,7 +4,7 @@ from map_data import STARTING_LOCATION_ID
 from monsters.monster_class import Monster  # Monsterクラスをインポート
 from monsters.monster_data import ALL_MONSTERS  # モンスター定義をインポート
 from items.item_data import ALL_ITEMS
-from synthesis_rules import SYNTHESIS_RECIPES # 合成レシピをインポート
+from synthesis_rules import SYNTHESIS_RECIPES, SYNTHESIS_ITEMS_REQUIRED
 import random # 将来的にスキル継承などで使うかも
 
 # Debug flag to control verbose output
@@ -260,6 +260,17 @@ class Player:
             print(f"[DEBUG player.py]   Available recipes in SYNTHESIS_RECIPES: {SYNTHESIS_RECIPES}")
 
         if recipe_key in SYNTHESIS_RECIPES:
+            # 合成に必要なアイテムがあればチェック
+            required_item = SYNTHESIS_ITEMS_REQUIRED.get(recipe_key)
+            if required_item:
+                item_index = next((i for i, itm in enumerate(self.items)
+                                   if getattr(itm, "item_id", None) == required_item), None)
+                if item_index is None:
+                    item_name = ALL_ITEMS[required_item].name if required_item in ALL_ITEMS else required_item
+                    return False, f"合成には {item_name} が必要だ。", None
+                # 消費アイテムとして取り除く
+                self.items.pop(item_index)
+
             result_monster_id = SYNTHESIS_RECIPES[recipe_key]
             
             if result_monster_id in ALL_MONSTERS:

--- a/synthesis_rules.py
+++ b/synthesis_rules.py
@@ -14,7 +14,12 @@ SYNTHESIS_RECIPES = {
     ("celestial_dragon", "shadow_panther"): "celestial_panther",
 }
 
-# 将来的には、合成に必要なアイテムなどもここに定義できる
-# SYNTHESIS_ITEMS_REQUIRED = {
-# "slime_goblin_hybrid": "magic_stone",
-# }
+# 合成に必要なアイテムの定義
+# キーは SYNTHESIS_RECIPES と同じタプル、値は必要なアイテムID
+SYNTHESIS_ITEMS_REQUIRED = {
+    ("orc_warrior", "slime"): "magic_stone",
+    ("elf_mage", "slime"): "frost_crystal",
+    ("orc_warrior", "skeleton_archer"): "abyss_shard",
+    ("giant_golem", "thunder_eagle"): "thunder_core",
+    ("celestial_dragon", "shadow_panther"): "celestial_feather",
+}


### PR DESCRIPTION
## Summary
- reinstate `Item` class removed by last commit
- add new synthesis material items and integrate usage
- add dictionary of required items for monster synthesis
- consume items in `Player.synthesize_monster`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403e75ce0483218c68f38ffaf21a3e