### PR TITLE
Add battle item usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
 Other notable modules include `player.py` (player data and save/load logic), `battle.py` (battle system), and `synthesis_rules.py` (monster fusion recipes).
 
 ## New Features
-- Items can now be used outside of battle. The included Small Potion heals 30 HP.
+- Items can now be used both outside and during battle. The included potions restore HP and can turn the tide mid-fight.
 - The starting village has a shop where you can buy Small Potions or even purchase a Slime companion.
 
 ## Saving

--- a/battle.py
+++ b/battle.py
@@ -235,9 +235,10 @@ def start_battle(player_party: list[Monster], enemy_party: list[Monster], player
                     print(f"\n>>> {actor.name} の行動！ <<<")
                     print("1: たたかう")
                     print("2: スキル")
-                    print("3: スカウト")
-                    print("4: にげる")
-                    action_choice = get_player_choice("行動を選んでください", 4)
+                    print("3: アイテム")
+                    print("4: スカウト")
+                    print("5: にげる")
+                    action_choice = get_player_choice("行動を選んでください", 5)
 
                     if action_choice == 1:  # たたかう
                         target = select_target(active_enemy_party, "\n攻撃対象を選んでください:")
@@ -301,7 +302,29 @@ def start_battle(player_party: list[Monster], enemy_party: list[Monster], player
                             print(f"{selected_skill.name} は適切な対象に使えなかった。")
                             continue
 
-                    elif action_choice == 3:  # スカウト
+                    elif action_choice == 3:  # アイテム
+                        if player is None:
+                            print("アイテムを使うプレイヤーがいない。")
+                            continue
+                        if not player.items:
+                            print("アイテムを持っていない。")
+                            continue
+                        player.show_items()
+                        item_choice = get_player_choice("使うアイテム番号を選んでください", len(player.items))
+                        if item_choice == 0:
+                            print("アイテム使用をキャンセルしました。")
+                            continue
+                        target_monster = select_target(active_player_party, "\n回復対象を選んでください:")
+                        if target_monster is None:
+                            print("アイテム使用をキャンセルしました。")
+                            continue
+                        used = player.use_item(item_choice - 1, target_monster)
+                        if used:
+                            break
+                        else:
+                            continue
+
+                    elif action_choice == 4:  # スカウト
                         target = select_target(active_enemy_party, "\nスカウトする対象を選んでください:")
                         if target:
                             attempt_scout(player, target, enemy_party)
@@ -312,7 +335,7 @@ def start_battle(player_party: list[Monster], enemy_party: list[Monster], player
                             print("スカウトをキャンセルしました。")
                             continue
 
-                    elif action_choice == 4:  # にげる
+                    elif action_choice == 5:  # にげる
                         print(f"\n{actor.name} は逃げ出そうとした！")
                         if random.random() < 0.5:
                             print("うまく逃げ切れた！")

--- a/player.py
+++ b/player.py
@@ -164,7 +164,13 @@ class Player:
             print(f"{item.name} はここでは使えない。")
             return False
 
-        if item.item_id == "small_potion":
+        heal_amounts = {
+            "small_potion": 30,
+            "medium_potion": 60,
+            "large_potion": 120,
+        }
+
+        if item.item_id in heal_amounts:
             if target_monster is None:
                 print("対象モンスターがいません。")
                 return False
@@ -172,9 +178,44 @@ class Player:
                 print(f"{target_monster.name} は倒れているため回復できない。")
                 return False
             before = target_monster.hp
-            target_monster.hp = min(target_monster.max_hp, target_monster.hp + 30)
+            target_monster.hp = min(target_monster.max_hp, target_monster.hp + heal_amounts[item.item_id])
             healed = target_monster.hp - before
             print(f"{target_monster.name} のHPが {healed} 回復した。")
+            self.items.pop(item_idx)
+            return True
+
+        if item.item_id == "ether":
+            if target_monster is None:
+                print("対象モンスターがいません。")
+                return False
+            before = target_monster.mp
+            target_monster.mp = min(target_monster.max_mp, target_monster.mp + 30)
+            restored = target_monster.mp - before
+            print(f"{target_monster.name} のMPが {restored} 回復した。")
+            self.items.pop(item_idx)
+            return True
+
+        if item.item_id == "elixir":
+            if target_monster is None:
+                print("対象モンスターがいません。")
+                return False
+            target_monster.hp = target_monster.max_hp
+            target_monster.mp = target_monster.max_mp
+            target_monster.is_alive = True
+            print(f"{target_monster.name} のHPとMPが全回復した！")
+            self.items.pop(item_idx)
+            return True
+
+        if item.item_id == "revive_scroll":
+            if target_monster is None:
+                print("対象モンスターがいません。")
+                return False
+            if target_monster.is_alive:
+                print(f"{target_monster.name} はまだ倒れていない。")
+                return False
+            target_monster.is_alive = True
+            target_monster.hp = target_monster.max_hp // 2
+            print(f"{target_monster.name} が復活した！ HPが半分回復した。")
             self.items.pop(item_idx)
             return True
 


### PR DESCRIPTION
## Summary
- allow choosing "アイテム" during battles
- implement effects for potions and other consumables
- document that items are usable during battle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c22984108321be6c212f4c197274