### PR TITLE
Refactor main functionalities into modules

### DIFF
--- a/battle_manager.py
+++ b/battle_manager.py
@@ -1,0 +1,24 @@
+# battle_manager.py
+from player import Player
+from database_setup import DATABASE_NAME
+
+
+def handle_battle_loss(hero: Player) -> str:
+    """Handle menu flow after the player loses a battle."""
+    while True:
+        print("\n--- GAME OVER ---")
+        print("1: リトライする")
+        print("2: セーブデータをロードする")
+        print("3: ゲームを終了する")
+        choice = input("選択: ").strip()
+        if choice == "1":
+            return "retry"
+        elif choice == "2":
+            loaded = Player.load_game(DATABASE_NAME)
+            if loaded:
+                hero.__dict__.update(loaded.__dict__)
+            return "load"
+        elif choice == "3":
+            return "exit"
+        else:
+            print("無効な選択です。")

--- a/exploration.py
+++ b/exploration.py
@@ -1,0 +1,59 @@
+# exploration.py
+import random
+from monsters import Monster, ALL_MONSTERS
+from map_data import Location
+
+
+def show_exploration_progress(progress: int) -> None:
+    """表示用の簡易プログレスバーを描画する"""
+    bar_length = 20
+    filled = int(bar_length * progress / 100)
+    bar = "#" * filled + "-" * (bar_length - filled)
+    print(f"探索度: [{bar}] {progress}%")
+
+
+def get_monster_instance_copy(monster_id_or_object: Monster | str) -> Monster | None:
+    """モンスターの新しいインスタンス（コピー）を返します。"""
+    if isinstance(monster_id_or_object, str):
+        monster_id = monster_id_or_object.lower()
+        if monster_id in ALL_MONSTERS:
+            new_monster = ALL_MONSTERS[monster_id].copy()
+            if new_monster:
+                new_monster.hp = new_monster.max_hp
+                new_monster.is_alive = True
+            return new_monster
+        else:
+            print(f"エラー: モンスターID '{monster_id}' は存在しません。")
+            return None
+    elif isinstance(monster_id_or_object, Monster):
+        new_monster = monster_id_or_object.copy()
+        if new_monster:
+            new_monster.hp = new_monster.max_hp
+            new_monster.is_alive = True
+        return new_monster
+    else:
+        print(f"エラー: 不正な引数です - {monster_id_or_object}")
+        return None
+
+
+def generate_enemy_party(location: Location) -> list[Monster]:
+    """指定された場所に基づいて敵パーティを生成します (1〜3体)。"""
+    enemy_party = []
+    if not location.possible_enemies:
+        return enemy_party
+
+    num_enemies = random.randint(1, min(3, len(location.possible_enemies)))
+
+    for _ in range(num_enemies):
+        enemy_id = random.choice(location.possible_enemies)
+        enemy_instance = get_monster_instance_copy(enemy_id)
+        if enemy_instance:
+            enemy_party.append(enemy_instance)
+
+    if not enemy_party and location.possible_enemies:
+        enemy_id = random.choice(location.possible_enemies)
+        enemy_instance = get_monster_instance_copy(enemy_id)
+        if enemy_instance:
+            enemy_party.append(enemy_instance)
+
+    return enemy_party

--- a/shop.py
+++ b/shop.py
@@ -1,0 +1,46 @@
+# shop.py
+from player import Player
+from monsters import ALL_MONSTERS
+from map_data import Location
+from items.item_data import ALL_ITEMS
+
+
+def open_shop(player: Player, location: Location):
+    if not getattr(location, 'has_shop', False):
+        print("ここにはお店はない。")
+        return
+
+    while True:
+        print("\n===== ショップ =====")
+        print(f"所持金: {player.gold}G")
+        options = []
+        idx = 1
+        for item_id, price in getattr(location, 'shop_items', {}).items():
+            item = ALL_ITEMS.get(item_id)
+            if item:
+                options.append(('item', item_id, price))
+                print(f"{idx}: {item.name} - {price}G")
+                idx += 1
+        for monster_id, price in getattr(location, 'shop_monsters', {}).items():
+            monster = ALL_MONSTERS.get(monster_id)
+            if monster:
+                options.append(('monster', monster_id, price))
+                print(f"{idx}: {monster.name} - {price}G")
+                idx += 1
+        print("0: やめる")
+
+        choice = input("購入する番号を選んでください: ")
+        if not choice.isdigit():
+            print("数字で入力してください。")
+            continue
+        c = int(choice)
+        if c == 0:
+            break
+        if 1 <= c <= len(options):
+            kind, obj_id, price = options[c-1]
+            if kind == 'item':
+                player.buy_item(obj_id, price)
+            else:
+                player.buy_monster(obj_id, price)
+        else:
+            print("無効な選択です。")


### PR DESCRIPTION
## Summary
- extract exploration helpers to `exploration.py`
- move shop logic to `shop.py`
- move battle-loss handler to `battle_manager.py`
- import the new modules from `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e2ad32f8832181c5358a3ae2da8d