### PR TITLE
Add item effects

### DIFF
--- a/items/item_data.py
+++ b/items/item_data.py
@@ -1,11 +1,12 @@
 # Item definitions
 
 class Item:
-    def __init__(self, item_id, name, description, usable=False):
+    def __init__(self, item_id, name, description, usable=False, effect=None):
         self.item_id = item_id
         self.name = name
         self.description = description
         self.usable = usable
+        self.effect = effect or {}
 
     def __repr__(self):
         return f"Item({self.item_id})"
@@ -16,6 +17,7 @@ small_potion = Item(
     name="スモールポーション",
     description="HPを少し回復する小さなポーション。",
     usable=True,
+    effect={"type": "heal_hp", "amount": 30},
 )
 
 medium_potion = Item(
@@ -23,6 +25,7 @@ medium_potion = Item(
     name="ミディアムポーション",
     description="HPを中程度回復するポーション。",
     usable=True,
+    effect={"type": "heal_hp", "amount": 60},
 )
 
 large_potion = Item(
@@ -30,6 +33,7 @@ large_potion = Item(
     name="ラージポーション",
     description="HPを大きく回復する高級ポーション。",
     usable=True,
+    effect={"type": "heal_hp", "amount": 120},
 )
 
 ether = Item(
@@ -37,6 +41,7 @@ ether = Item(
     name="エーテル",
     description="MPを中程度回復する神秘の液体。",
     usable=True,
+    effect={"type": "heal_mp", "amount": 30},
 )
 
 antidote = Item(
@@ -44,6 +49,7 @@ antidote = Item(
     name="アンチドート",
     description="毒状態を治療する解毒薬。",
     usable=True,
+    effect={"type": "cure_status", "status": "poison"},
 )
 
 elixir = Item(
@@ -51,6 +57,7 @@ elixir = Item(
     name="エリクサー",
     description="HPとMPを完全に回復する万能薬。",
     usable=True,
+    effect={"type": "heal_full"},
 )
 
 revive_scroll = Item(
@@ -58,6 +65,7 @@ revive_scroll = Item(
     name="リバイブスクロール",
     description="戦闘不能の味方1体を復活させる古文書。",
     usable=True,
+    effect={"type": "revive", "amount": "half"},
 )
 
 # ── モンスター合成素材 ──────────────────────────────

--- a/player.py
+++ b/player.py
@@ -191,38 +191,41 @@ class Player:
             print(f"{item.name} はここでは使えない。")
             return False
 
-        heal_amounts = {
-            "small_potion": 30,
-            "medium_potion": 60,
-            "large_potion": 120,
-        }
+        effect = getattr(item, "effect", {})
+        if not effect:
+            print("このアイテムはまだ効果が実装されていない。")
+            return False
 
-        if item.item_id in heal_amounts:
+        etype = effect.get("type")
+
+        if etype == "heal_hp":
             if target_monster is None:
                 print("対象モンスターがいません。")
                 return False
             if not target_monster.is_alive:
                 print(f"{target_monster.name} は倒れているため回復できない。")
                 return False
+            amount = effect.get("amount", 0)
             before = target_monster.hp
-            target_monster.hp = min(target_monster.max_hp, target_monster.hp + heal_amounts[item.item_id])
+            target_monster.hp = min(target_monster.max_hp, target_monster.hp + amount)
             healed = target_monster.hp - before
             print(f"{target_monster.name} のHPが {healed} 回復した。")
             self.items.pop(item_idx)
             return True
 
-        if item.item_id == "ether":
+        if etype == "heal_mp":
             if target_monster is None:
                 print("対象モンスターがいません。")
                 return False
+            amount = effect.get("amount", 0)
             before = target_monster.mp
-            target_monster.mp = min(target_monster.max_mp, target_monster.mp + 30)
+            target_monster.mp = min(target_monster.max_mp, target_monster.mp + amount)
             restored = target_monster.mp - before
             print(f"{target_monster.name} のMPが {restored} 回復した。")
             self.items.pop(item_idx)
             return True
 
-        if item.item_id == "elixir":
+        if etype == "heal_full":
             if target_monster is None:
                 print("対象モンスターがいません。")
                 return False
@@ -233,7 +236,7 @@ class Player:
             self.items.pop(item_idx)
             return True
 
-        if item.item_id == "revive_scroll":
+        if etype == "revive":
             if target_monster is None:
                 print("対象モンスターがいません。")
                 return False
@@ -241,7 +244,11 @@ class Player:
                 print(f"{target_monster.name} はまだ倒れていない。")
                 return False
             target_monster.is_alive = True
-            target_monster.hp = target_monster.max_hp // 2
+            amount = effect.get("amount", "half")
+            if amount == "half":
+                target_monster.hp = target_monster.max_hp // 2
+            else:
+                target_monster.hp = min(target_monster.max_hp, int(amount))
             print(f"{target_monster.name} が復活した！ HPが半分回復した。")
             self.items.pop(item_idx)
             return True


### PR DESCRIPTION
## Summary
- extend `Item` class to include `effect` data
- assign effect dictionaries to each consumable item
- refactor `Player.use_item` to apply effects based on the item data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e6e8a59483218525797e9d2d84ff