### PR TITLE
Refactor web_main with templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
    pip install -r requirements.txt
    python web_main.py
    ```
-   This starts the server at <http://localhost:5000/>.
+   This starts the server at <http://localhost:5000/> and now uses
+   Flask templates for a slightly nicer appearance.
 
 ## Project Structure
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,16 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 1rem;
+}
+header {
+    background-color: #444;
+    color: white;
+    padding: 1rem;
+}
+main {
+    margin-top: 1rem;
+}
+button {
+    margin-top: 0.5rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,11 @@
+{% extends "layout.html" %}
+{% block content %}
+<form action="{{ url_for('start_game') }}" method="post">
+  <input name="username" placeholder="名前">
+  <button type="submit">新規ゲーム</button>
+</form>
+<form action="{{ url_for('load_existing') }}" method="post">
+  <input name="user_id" placeholder="User ID">
+  <button type="submit">ロード</button>
+</form>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>{{ title or "Monster RPG" }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <header>
+    <h1>Monster RPG</h1>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/templates/party.html
+++ b/templates/party.html
@@ -1,0 +1,10 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>パーティ</h2>
+<ul>
+{% for m in player.party_monsters %}
+<li>{{ m.name }} Lv.{{ m.level }} HP {{ m.hp }}/{{ m.max_hp }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/play.html
+++ b/templates/play.html
@@ -1,0 +1,16 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>{{ loc.name }}</h2>
+<p>{{ loc.description }}</p>
+<p>Player: {{ player.name }} Lv.{{ player.player_level }} Gold {{ player.gold }}</p>
+<h3>移動</h3>
+{% for cmd, dest, name in connections %}
+<form action="{{ url_for('move', user_id=user_id) }}" method="post">
+  <input type="hidden" name="dest" value="{{ dest }}">
+  <button type="submit">{{ cmd }} -> {{ name }}</button>
+</form>
+{% endfor %}
+<form action="{{ url_for('status', user_id=user_id) }}" method="get"><button>ステータス</button></form>
+<form action="{{ url_for('party', user_id=user_id) }}" method="get"><button>パーティ</button></form>
+<form action="{{ url_for('save', user_id=user_id) }}" method="post"><button>セーブ</button></form>
+{% endblock %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>{{ player.name }} のステータス</h2>
+<p>Lv {{ player.player_level }} EXP {{ player.exp }} Gold {{ player.gold }}</p>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- refactor `web_main.py` to use Flask templates and add docstrings
- add HTML templates and a simple stylesheet
- document the improved web interface in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ff9ae8ec8321a5c62448683225e8