### PR TITLE
Add basic gameplay features to web interface

### DIFF
--- a/templates/explore.html
+++ b/templates/explore.html
@@ -1,0 +1,10 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>探索結果</h2>
+<ul>
+{% for m in messages %}
+  <li>{{ m }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/items.html
+++ b/templates/items.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>アイテム</h2>
+<p>所持金 {{ player.gold }}G</p>
+{% if message %}<p>{{ message }}</p>{% endif %}
+{% if player.items %}
+<ul>
+{% for item in player.items %}
+  {% set idx = loop.index0 %}
+  <li>{{ item.name }}
+    <form action="{{ url_for('items', user_id=user_id) }}" method="post" style="display:inline">
+      <input type="hidden" name="item_idx" value="{{ idx }}">
+      <select name="target_idx">
+      {% for m in player.party_monsters %}
+        <option value="{{ loop.index0 }}">{{ m.name }}</option>
+      {% endfor %}
+      </select>
+      <button type="submit">使う</button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+{% else %}
+<p>アイテムを持っていない。</p>
+{% endif %}
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,0 +1,12 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>ワールドマップ</h2>
+<pre>{{ overview }}</pre>
+<h3>探索度</h3>
+<ul>
+{% for loc_id, val in progress.items() %}
+  <li>{{ locations[loc_id].name }}: {{ val }}%</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/play.html
+++ b/templates/play.html
@@ -12,5 +12,14 @@
 {% endfor %}
 <form action="{{ url_for('status', user_id=user_id) }}" method="get"><button>ステータス</button></form>
 <form action="{{ url_for('party', user_id=user_id) }}" method="get"><button>パーティ</button></form>
+<form action="{{ url_for('explore', user_id=user_id) }}" method="post"><button>探索</button></form>
+<form action="{{ url_for('items', user_id=user_id) }}" method="get"><button>アイテム</button></form>
+<form action="{{ url_for('map', user_id=user_id) }}" method="get"><button>マップ</button></form>
+{% if loc.has_shop %}
+<form action="{{ url_for('shop', user_id=user_id) }}" method="get"><button>ショップ</button></form>
+{% endif %}
+{% if loc.has_inn %}
+<form action="{{ url_for('inn', user_id=user_id) }}" method="post"><button>宿屋 ({{ loc.inn_cost }})</button></form>
+{% endif %}
 <form action="{{ url_for('save', user_id=user_id) }}" method="post"><button>セーブ</button></form>
 {% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block content %}
+<p>{{ message }}</p>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/shop.html
+++ b/templates/shop.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>ショップ</h2>
+<p>所持金 {{ player.gold }}G</p>
+{% if message %}<p>{{ message }}</p>{% endif %}
+<ul>
+{% for kind, obj_id, name, price in entries %}
+  <li>{{ name }} - {{ price }}G
+    <form action="{{ url_for('shop', user_id=user_id) }}" method="post" style="display:inline">
+      {% if kind == 'item' %}
+      <input type="hidden" name="buy_item" value="{{ obj_id }}">
+      {% else %}
+      <input type="hidden" name="buy_monster" value="{{ obj_id }}">
+      {% endif %}
+      <button type="submit">購入</button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/web_main.py
+++ b/web_main.py
@@ -1,11 +1,14 @@
 """Simple web interface for the Monster RPG game."""
 
 from flask import Flask, request, redirect, url_for, render_template
+import random
 
 import database_setup
 from player import Player
 from monsters.monster_data import ALL_MONSTERS
-from map_data import LOCATIONS
+from items.item_data import ALL_ITEMS
+from map_data import LOCATIONS, get_map_overview
+from exploration import generate_enemy_party
 
 app = Flask(__name__)
 
@@ -13,6 +16,65 @@ database_setup.initialize_database()
 
 # In-memory store of active players keyed by user_id
 active_players: dict[int, Player] = {}
+
+
+def run_simple_battle(player_party: list, enemy_party: list):
+    """Very simplified auto battle returning outcome and log messages."""
+    log = []
+    while any(m.is_alive for m in player_party) and any(e.is_alive for e in enemy_party):
+        for p in player_party:
+            if not p.is_alive:
+                continue
+            target = next((e for e in enemy_party if e.is_alive), None)
+            if not target:
+                break
+            dmg = max(1, p.attack - target.defense)
+            target.hp -= dmg
+            log.append(f"{p.name} attacks {target.name} for {dmg}")
+            if target.hp <= 0:
+                target.is_alive = False
+                log.append(f"{target.name} was defeated")
+        for e in enemy_party:
+            if not e.is_alive:
+                continue
+            target = next((m for m in player_party if m.is_alive), None)
+            if not target:
+                break
+            dmg = max(1, e.attack - target.defense)
+            target.hp -= dmg
+            log.append(f"{e.name} attacks {target.name} for {dmg}")
+            if target.hp <= 0:
+                target.is_alive = False
+                log.append(f"{target.name} fell")
+    outcome = "win" if any(m.is_alive for m in player_party) else "lose"
+    return outcome, log
+
+
+def handle_battle(player: Player, location) -> list[str]:
+    """Generate enemies and run a simple battle, returning log messages."""
+    msgs: list[str] = []
+    enemies = generate_enemy_party(location)
+    if not enemies:
+        msgs.append("モンスターは現れなかった。")
+        return msgs
+    enemy_names = ", ".join(e.name for e in enemies)
+    msgs.append(f"{enemy_names} が現れた！")
+    party = player.party_monsters
+    outcome, battle_log = run_simple_battle(party, enemies)
+    msgs.extend(battle_log)
+    if outcome == "win":
+        total_exp = sum(e.level * 10 for e in enemies)
+        gold_gain = sum(e.level * 5 for e in enemies)
+        alive_members = [m for m in party if m.is_alive]
+        if alive_members and total_exp:
+            share = total_exp // len(alive_members)
+            for m in alive_members:
+                m.gain_exp(share)
+        player.gold += gold_gain
+        msgs.append(f"勝利した！ {gold_gain}G を得た。")
+    else:
+        msgs.append("敗北してしまった...")
+    return msgs
 
 @app.route('/')
 def index():
@@ -80,6 +142,106 @@ def party(user_id):
     if not player:
         return redirect(url_for('index'))
     return render_template("party.html", player=player, user_id=user_id)
+
+
+@app.route('/items/<int:user_id>', methods=['GET', 'POST'])
+def items(user_id):
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    message = None
+    if request.method == 'POST':
+        try:
+            idx = int(request.form.get('item_idx', -1))
+            target_idx = int(request.form.get('target_idx', -1))
+        except (TypeError, ValueError):
+            idx = target_idx = -1
+        if 0 <= idx < len(player.items) and 0 <= target_idx < len(player.party_monsters):
+            item_name = player.items[idx].name
+            success = player.use_item(idx, player.party_monsters[target_idx])
+            message = f"{item_name} を使った。" if success else "アイテムを使えなかった。"
+    return render_template('items.html', player=player, user_id=user_id, message=message)
+
+
+@app.route('/shop/<int:user_id>', methods=['GET', 'POST'])
+def shop(user_id):
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    loc = LOCATIONS.get(player.current_location_id)
+    if not loc or not getattr(loc, 'has_shop', False):
+        return redirect(url_for('play', user_id=user_id))
+
+    message = None
+    if request.method == 'POST':
+        if 'buy_item' in request.form:
+            item_id = request.form['buy_item']
+            price = loc.shop_items.get(item_id)
+            if price is not None and player.buy_item(item_id, price):
+                name = ALL_ITEMS[item_id].name if item_id in ALL_ITEMS else item_id
+                message = f"{name} を購入した。"
+            else:
+                message = "購入できなかった。"
+        elif 'buy_monster' in request.form:
+            monster_id = request.form['buy_monster']
+            price = loc.shop_monsters.get(monster_id)
+            if price is not None and player.buy_monster(monster_id, price):
+                mname = ALL_MONSTERS[monster_id].name if monster_id in ALL_MONSTERS else monster_id
+                message = f"{mname} を仲間にした。"
+            else:
+                message = "購入できなかった。"
+
+    entries = []
+    for iid, pr in loc.shop_items.items():
+        name = ALL_ITEMS[iid].name if iid in ALL_ITEMS else iid
+        entries.append(('item', iid, name, pr))
+    for mid, pr in loc.shop_monsters.items():
+        mname = ALL_MONSTERS[mid].name if mid in ALL_MONSTERS else mid
+        entries.append(('monster', mid, mname, pr))
+    return render_template('shop.html', player=player, user_id=user_id, entries=entries, message=message)
+
+
+@app.route('/inn/<int:user_id>', methods=['POST'])
+def inn(user_id):
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    loc = LOCATIONS.get(player.current_location_id)
+    if not loc or not getattr(loc, 'has_inn', False):
+        return redirect(url_for('play', user_id=user_id))
+    cost = getattr(loc, 'inn_cost', 10)
+    success = player.rest_at_inn(cost)
+    msg = '宿屋で休んだ。' if success else 'お金が足りない。'
+    return render_template('result.html', message=msg, user_id=user_id)
+
+
+@app.route('/explore/<int:user_id>', methods=['POST'])
+def explore(user_id):
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    loc = LOCATIONS.get(player.current_location_id)
+    if not loc:
+        return redirect(url_for('play', user_id=user_id))
+    messages = []
+    before = player.get_exploration(player.current_location_id)
+    gained = random.randint(15, 30)
+    after = player.increase_exploration(player.current_location_id, gained)
+    messages.append(f"探索度 {before}% -> {after}%")
+    if loc.possible_enemies and random.random() < loc.encounter_rate:
+        messages.extend(handle_battle(player, loc))
+    else:
+        messages.append('モンスターは現れなかった。')
+    return render_template('explore.html', messages=messages, user_id=user_id)
+
+
+@app.route('/map/<int:user_id>')
+def world_map(user_id):
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    overview = get_map_overview()
+    return render_template('map.html', overview=overview, progress=player.exploration_progress, locations=LOCATIONS, user_id=user_id)
 
 @app.route('/move/<int:user_id>', methods=['POST'])
 def move(user_id):


### PR DESCRIPTION
## Summary
- add helper battle logic and new endpoints in `web_main.py`
- extend play page with more actions
- add templates for items, shop, exploration, map, and generic result pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684101922e2c8321b6841037fe2a2613