### PR TITLE
Add password hashing for users

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -7,7 +7,7 @@ app = Flask(__name__)
 db_name = database_setup.DATABASE_NAME
 
 def get_or_create_user(username: str, password: str) -> int:
-    user_id = database_setup.get_user_id(username)
+    user_id = database_setup.get_user_id(username, password)
     if user_id is None:
         user_id = database_setup.create_user(username, password)
     return user_id


### PR DESCRIPTION
## Summary
- hash passwords with SHA-256 when users are created
- verify password on user lookup
- update web API to use hashed password verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684107bee71483219cfc2be9d76b54e2