### PR TITLE
Implement monster party formation feature

### DIFF
--- a/player.py
+++ b/player.py
@@ -169,6 +169,17 @@ class Player:
             monster.show_status()
         print("=" * 30)
 
+    def move_monster(self, from_idx: int, to_idx: int) -> bool:
+        """パーティ内でモンスターの位置を移動する。"""
+        if not (
+            0 <= from_idx < len(self.party_monsters)
+            and 0 <= to_idx < len(self.party_monsters)
+        ):
+            return False
+        monster = self.party_monsters.pop(from_idx)
+        self.party_monsters.insert(to_idx, monster)
+        return True
+
     def show_items(self):
         if not self.items:
             print("アイテムを何も持っていない。")

--- a/templates/formation.html
+++ b/templates/formation.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>編成</h2>
+<ul>
+{% for m in player.party_monsters %}
+  <li>{{ loop.index }}. {{ m.name }}
+    <form action="{{ url_for('formation', user_id=user_id) }}" method="post" style="display:inline">
+      <input type="hidden" name="index" value="{{ loop.index0 }}">
+      {% if not loop.first %}
+      <button type="submit" name="move" value="up">↑</button>
+      {% endif %}
+      {% if not loop.last %}
+      <button type="submit" name="move" value="down">↓</button>
+      {% endif %}
+    </form>
+  </li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('party', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/party.html
+++ b/templates/party.html
@@ -6,5 +6,8 @@
 <li>{{ m.name }} Lv.{{ m.level }} HP {{ m.hp }}/{{ m.max_hp }}</li>
 {% endfor %}
 </ul>
+<form action="{{ url_for('formation', user_id=user_id) }}" method="get">
+  <button>編成</button>
+</form>
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
 {% endblock %}

--- a/tests/test_party_formation.py
+++ b/tests/test_party_formation.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from player import Player
+from monsters.monster_data import ALL_MONSTERS
+
+class PartyFormationTests(unittest.TestCase):
+    def setUp(self):
+        self.player = Player('Tester')
+        for mid in ('slime', 'goblin', 'wolf'):
+            if mid in ALL_MONSTERS:
+                self.player.add_monster_to_party(mid)
+
+    def test_move_monster(self):
+        ids_before = [m.monster_id for m in self.player.party_monsters]
+        self.assertEqual(ids_before, ['slime', 'goblin', 'wolf'])
+        self.player.move_monster(0, 2)
+        ids_after = [m.monster_id for m in self.player.party_monsters]
+        self.assertEqual(ids_after, ['goblin', 'wolf', 'slime'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/web_main.py
+++ b/web_main.py
@@ -144,6 +144,25 @@ def party(user_id):
     return render_template("party.html", player=player, user_id=user_id)
 
 
+@app.route('/formation/<int:user_id>', methods=['GET', 'POST'])
+def formation(user_id):
+    """Allow reordering of the player's party."""
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        try:
+            idx = int(request.form.get('index', -1))
+        except (TypeError, ValueError):
+            idx = -1
+        move = request.form.get('move')
+        if move == 'up':
+            player.move_monster(idx, idx - 1)
+        elif move == 'down':
+            player.move_monster(idx, idx + 1)
+    return render_template('formation.html', player=player, user_id=user_id)
+
+
 @app.route('/items/<int:user_id>', methods=['GET', 'POST'])
 def items(user_id):
     player = active_players.get(user_id)


### PR DESCRIPTION
## Summary
- allow moving monster positions in `Player.move_monster`
- add new `/formation` route and template for reordering
- link formation screen from party page
- cover `move_monster` with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841068e49048321a9f84a178ec54ce9