### PR TITLE
Implement buff and exp improvements

### DIFF
--- a/tests/test_exp_distribution.py
+++ b/tests/test_exp_distribution.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from battle import award_experience
+from monsters.monster_class import Monster
+
+class ExperienceDistributionTests(unittest.TestCase):
+    def test_experience_split_with_remainder(self):
+        p1 = Monster('M1', hp=20, attack=5, defense=5)
+        p2 = Monster('M2', hp=20, attack=5, defense=5)
+        p3 = Monster('M3', hp=20, attack=5, defense=5)
+        p3.is_alive = False
+        enemy = Monster('E', hp=55, attack=5, defense=5, level=1)
+        enemy.is_alive = False
+        award_experience([p1, p2, p3], [enemy], None)
+        self.assertEqual(p1.exp, 11)
+        self.assertEqual(p2.exp, 10)
+        self.assertEqual(p3.exp, 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_party_buff.py
+++ b/tests/test_party_buff.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from battle import apply_skill_effect, process_status_effects
+from monsters.monster_class import Monster
+from skills.skills import ALL_SKILLS
+
+class PartyBuffTests(unittest.TestCase):
+    def test_brave_song_buff_applies_to_all_allies(self):
+        m1 = Monster('Hero', hp=30, attack=10, defense=10)
+        m2 = Monster('Ally', hp=30, attack=12, defense=12)
+        allies = [m1, m2]
+        skill = ALL_SKILLS['brave_song']
+        apply_skill_effect(m1, [m1], skill, all_allies=allies)
+        self.assertEqual(m1.attack, 15)
+        self.assertEqual(m2.attack, 17)
+        # effect should wear off after duration turns
+        for _ in range(skill.duration):
+            for m in allies:
+                process_status_effects(m)
+        self.assertEqual(m1.attack, 10)
+        self.assertEqual(m2.attack, 12)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support party-wide buffs like Brave Song
- refine EXP reward distribution using new `award_experience` helper
- test buffs affect all allies and that EXP splits correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684107b5aef88321a081ac445fb95ba5