### PR TITLE
Fix missing Flask import guidance

### DIFF
--- a/web_main.py
+++ b/web_main.py
@@ -1,6 +1,12 @@
 """Simple web interface for the Monster RPG game."""
 
-from flask import Flask, request, redirect, url_for, render_template
+try:
+    from flask import Flask, request, redirect, url_for, render_template
+except ImportError as e:  # pragma: no cover - dependency check
+    raise SystemExit(
+        "Flask is required to run this web interface. "
+        "Install dependencies with 'pip install -r requirements.txt'."
+    ) from e
 import random
 
 import database_setup


### PR DESCRIPTION
## Summary
- handle ImportError when Flask is missing so users see a helpful message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841131aec588321b962ca0e3a8670be