### PR TITLE
Add monster item drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Other notable modules include `player.py` (player data and save/load logic), `ba
 ## New Features
 - Items can now be used both outside and during battle. The included potions restore HP and can turn the tide mid-fight.
 - The starting village has a shop where you can buy Small Potions or even purchase a Slime companion.
+- Defeated monsters may drop items, which are automatically added to your inventory.
 
 ## Saving
 The game saves player data to `monster_rpg_save.db`. Only basic information is stored at the moment, but the structure is ready for expansion.

--- a/monsters/monster_data.py
+++ b/monsters/monster_data.py
@@ -2,6 +2,7 @@
 
 from .monster_class import Monster, GROWTH_TYPE_AVERAGE, GROWTH_TYPE_EARLY, GROWTH_TYPE_LATE
 from skills.skills import ALL_SKILLS
+from items.item_data import ALL_ITEMS
 
 # モンスターランク定義
 RANK_S = "S"
@@ -16,7 +17,8 @@ SLIME = Monster(
     skills=[ALL_SKILLS["heal"]] if "heal" in ALL_SKILLS else [],
     growth_type=GROWTH_TYPE_EARLY,
     monster_id="slime",
-    rank=RANK_D # 例: スライムはDランク
+    rank=RANK_D, # 例: スライムはDランク
+    drop_items=[(ALL_ITEMS["small_potion"], 0.5)]
 )
 
 GOBLIN = Monster(
@@ -24,15 +26,17 @@ GOBLIN = Monster(
     skills=[ALL_SKILLS["fireball"]] if "fireball" in ALL_SKILLS else [],
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="goblin",
-    rank=RANK_D # 例: ゴブリンはDランク
+    rank=RANK_D, # 例: ゴブリンはDランク
+    drop_items=[(ALL_ITEMS["small_potion"], 0.2), (ALL_ITEMS["magic_stone"], 0.1)]
 )
 
 WOLF = Monster(
     name="ウルフ", hp=50, attack=15, defense=7, level=3, element="なし",speed=10,
-    skills=[], 
+    skills=[],
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="wolf",
-    rank=RANK_C # 例: ウルフはCランク
+    rank=RANK_C, # 例: ウルフはCランク
+    drop_items=[(ALL_ITEMS["medium_potion"], 0.1)]
 )
 
 SLIME_GOBLIN_HYBRID = Monster(

--- a/tests/test_item_drop.py
+++ b/tests/test_item_drop.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import random
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from battle import award_experience
+from items.item_data import ALL_ITEMS
+from monsters.monster_class import Monster
+from player import Player
+
+class ItemDropTests(unittest.TestCase):
+    def test_drop_item_added_to_player(self):
+        enemy = Monster('Enemy', hp=30, attack=10, defense=5, level=1,
+                        drop_items=[(ALL_ITEMS['small_potion'], 1.0)])
+        enemy.is_alive = False
+        ally = Monster('Ally', hp=30, attack=10, defense=5)
+        player = Player('Tester')
+        player.party_monsters.append(ally)
+        random.seed(0)
+        award_experience([ally], [enemy], player)
+        self.assertEqual(len(player.items), 1)
+        self.assertEqual(player.items[0].item_id, 'small_potion')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- import ALL_ITEMS in monster data
- add drop items for Slime, Goblin and Wolf
- mention dropped items in README
- test awarding drop items works

## Testing
- `pip install -q Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684119759d3883218ef69b33b99078e4