### PR TITLE
Implement enemy skill usage

### DIFF
--- a/tests/test_enemy_skill_usage.py
+++ b/tests/test_enemy_skill_usage.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from battle import enemy_take_action
+from monsters.monster_class import Monster
+from skills.skills import ALL_SKILLS
+
+
+def test_enemy_heals_when_using_skill(monkeypatch):
+    hero = Monster('Hero', hp=50, attack=10, defense=5, speed=5)
+    enemy = Monster('Enemy', hp=30, attack=5, defense=2, speed=5,
+                    skills=[ALL_SKILLS['heal']])
+    enemy.hp = 10
+    players = [hero]
+    enemies = [enemy]
+
+    monkeypatch.setattr('random.random', lambda: 0.0)
+    monkeypatch.setattr('random.choice', lambda seq: seq[0])
+
+    enemy_take_action(enemy, players, enemies)
+
+    assert enemy.hp > 10


### PR DESCRIPTION
## Summary
- let enemies use skills during battle
- add `enemy_take_action` helper and call it from `start_battle`
- test enemy skill use with a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684124567df08321a84e46777765e993