### PR TITLE
Implement inheritance in monster synthesis

### DIFF
--- a/tests/test_synthesis_inheritance.py
+++ b/tests/test_synthesis_inheritance.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from player import Player
+from monsters.monster_data import ALL_MONSTERS
+
+class SynthesisInheritanceTests(unittest.TestCase):
+    def test_skill_and_stat_inheritance(self):
+        player = Player('Tester')
+        player.add_monster_to_party('slime')
+        player.add_monster_to_party('wolf')
+
+        player.party_monsters[0].level = 5
+        player.party_monsters[1].level = 5
+
+        success, msg, child = player.synthesize_monster(0, 1)
+        self.assertTrue(success)
+        self.assertIsNotNone(child)
+        self.assertEqual(child.monster_id, 'water_wolf')
+
+        # Child should inherit heal from slime
+        skill_names = [s.name for s in child.skills]
+        self.assertIn('ヒール', skill_names)
+
+        # Stats should receive a bonus
+        template = ALL_MONSTERS['water_wolf']
+        self.assertGreater(child.max_hp, template.max_hp)
+        self.assertGreater(child.attack, template.attack)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance `Player.synthesize_monster` with skill/stat inheritance
- add new unit test for synthesis inheritance

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684126bc63c8832184e2fd305076cbbb