### PR TITLE
Add monster encyclopedia feature

### DIFF
--- a/exploration.py
+++ b/exploration.py
@@ -36,7 +36,7 @@ def get_monster_instance_copy(monster_id_or_object: Monster | str) -> Monster | 
         return None
 
 
-def generate_enemy_party(location: Location) -> list[Monster]:
+def generate_enemy_party(location: Location, player=None) -> list[Monster]:
     """指定された場所に基づいて敵パーティを生成します (1〜3体)。"""
     enemy_party = []
     if not location.possible_enemies:
@@ -49,6 +49,8 @@ def generate_enemy_party(location: Location) -> list[Monster]:
         enemy_id = random.choice(location.possible_enemies)
         enemy_instance = get_monster_instance_copy(enemy_id)
         if enemy_instance:
+            if player is not None and hasattr(player, "monster_book"):
+                player.monster_book.record_seen(enemy_instance.monster_id)
             target_level = max(1, base_level + random.randint(-1, 1))
             while enemy_instance.level < target_level:
                 enemy_instance.level_up()
@@ -58,6 +60,8 @@ def generate_enemy_party(location: Location) -> list[Monster]:
         enemy_id = random.choice(location.possible_enemies)
         enemy_instance = get_monster_instance_copy(enemy_id)
         if enemy_instance:
+            if player is not None and hasattr(player, "monster_book"):
+                player.monster_book.record_seen(enemy_instance.monster_id)
             target_level = max(1, base_level + random.randint(-1, 1))
             while enemy_instance.level < target_level:
                 enemy_instance.level_up()

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ def game_loop(hero: Player): # 型ヒントを追加
 
         print("9: ゲームをセーブ")
         print("10: マップを見る")
+        print("11: モンスター図鑑")
         print("0: ゲーム終了")
 
         action = input("行動を選んでください (番号): ")
@@ -98,7 +99,7 @@ def game_loop(hero: Player): # 型ヒントを追加
                         player_battle_party = hero.party_monsters 
 
                         # 敵パーティを生成
-                        enemy_battle_party = generate_enemy_party(new_location_data)
+                        enemy_battle_party = generate_enemy_party(new_location_data, hero)
                         
                         if not player_battle_party: # プレイヤーのパーティが空の場合
                             print("手持ちモンスターがいない！逃げるしかない！")
@@ -232,7 +233,7 @@ def game_loop(hero: Player): # 型ヒントを追加
             elif current_location_data.possible_enemies and random.random() < current_location_data.encounter_rate:
                 print("\n!!!モンスターが襲ってきた!!!")
                 player_battle_party = hero.party_monsters
-                enemy_battle_party = generate_enemy_party(current_location_data)
+                enemy_battle_party = generate_enemy_party(current_location_data, hero)
                 if enemy_battle_party:
                     battle_outcome_result_str = start_battle(player_battle_party, enemy_battle_party, hero)
                     if battle_outcome_result_str == "win":
@@ -292,6 +293,9 @@ def game_loop(hero: Player): # 型ヒントを追加
 
         elif action == "10":
             display_map()
+
+        elif action == "11":
+            hero.monster_book.show_book()
 
         elif action == "0": # ゲーム終了
             print("ゲームを終了します。お疲れ様でした！")

--- a/monster_book.py
+++ b/monster_book.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+from typing import Dict, Set
+
+@dataclass
+class MonsterBookEntry:
+    monster_id: str
+    description: str
+    synthesis_hint: str = ""
+    reward: int = 0
+
+# 図鑑に登録するモンスター情報
+MONSTER_BOOK_DATA: Dict[str, MonsterBookEntry] = {
+    "slime": MonsterBookEntry(
+        monster_id="slime",
+        description="ぷるぷるした弱小モンスター。水属性で、初心者の相手に最適。",
+        synthesis_hint="別種族と掛け合わせると特殊なモンスターが生まれるかも。",
+    ),
+    "wolf": MonsterBookEntry(
+        monster_id="wolf",
+        description="俊敏な牙獣。群れで行動することが多い。",
+        synthesis_hint="水に関連したモンスターと相性が良い。",
+    ),
+    "water_wolf": MonsterBookEntry(
+        monster_id="water_wolf",
+        description="水辺に潜むウルフ。鋭い爪で襲いかかる。",
+        synthesis_hint="スライムとウルフを組み合わせると誕生するらしい。",
+    ),
+}
+
+class MonsterBook:
+    """プレイヤー毎に所持するモンスター図鑑。"""
+
+    def __init__(self) -> None:
+        self.seen: Set[str] = set()
+        self.captured: Set[str] = set()
+
+    def record_seen(self, monster_id: str) -> None:
+        if monster_id in MONSTER_BOOK_DATA:
+            self.seen.add(monster_id)
+
+    def record_captured(self, monster_id: str) -> None:
+        if monster_id in MONSTER_BOOK_DATA:
+            self.seen.add(monster_id)
+            self.captured.add(monster_id)
+
+    def completion_rate(self) -> float:
+        total = len(MONSTER_BOOK_DATA)
+        return (len(self.captured) / total) * 100 if total else 0.0
+
+    def show_book(self) -> None:
+        print("===== モンスター図鑑 =====")
+        for mid, entry in MONSTER_BOOK_DATA.items():
+            if mid in self.seen:
+                status = "捕獲" if mid in self.captured else "目撃"
+                print(f"{entry.monster_id} [{status}]")
+                print(f"  {entry.description}")
+                if entry.synthesis_hint:
+                    print(f"  合成ヒント: {entry.synthesis_hint}")
+            else:
+                print("??? [未発見]")
+        rate = self.completion_rate()
+        print(f"発見率: {rate:.1f}%")
+        print("=========================")

--- a/player.py
+++ b/player.py
@@ -7,6 +7,7 @@ from items.item_data import ALL_ITEMS
 from synthesis_rules import SYNTHESIS_RECIPES, SYNTHESIS_ITEMS_REQUIRED
 import random  # 将来的にスキル継承などで使うかも
 import copy
+from monster_book import MonsterBook
 
 # Debug flag to control verbose output
 DEBUG_MODE = False
@@ -23,6 +24,7 @@ class Player:
         self.db_id = None # データベース上のID (ロード時に設定)
         self.user_id = user_id
         self.exploration_progress = {}
+        self.monster_book = MonsterBook()
 
     def save_game(self, db_name, user_id=None):
         conn = sqlite3.connect(db_name)
@@ -157,6 +159,7 @@ class Player:
         
         if newly_added_monster:
             print(f"[DEBUG player.py add_monster_to_party] Actual monster_id of added monster '{newly_added_monster.name}': '{newly_added_monster.monster_id}' (type: {type(newly_added_monster.monster_id)})")
+            self.monster_book.record_captured(newly_added_monster.monster_id)
 
 
     def show_all_party_monsters_status(self):

--- a/tests/test_monster_book.py
+++ b/tests/test_monster_book.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from player import Player
+from monsters.monster_data import ALL_MONSTERS
+
+class MonsterBookTests(unittest.TestCase):
+    def test_record_captured(self):
+        player = Player('Tester')
+        self.assertNotIn('slime', player.monster_book.captured)
+        player.add_monster_to_party('slime')
+        self.assertIn('slime', player.monster_book.captured)
+        self.assertIn('slime', player.monster_book.seen)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/web_main.py
+++ b/web_main.py
@@ -59,7 +59,7 @@ def run_simple_battle(player_party: list, enemy_party: list):
 def handle_battle(player: Player, location) -> list[str]:
     """Generate enemies and run a simple battle, returning log messages."""
     msgs: list[str] = []
-    enemies = generate_enemy_party(location)
+    enemies = generate_enemy_party(location, player)
     if not enemies:
         msgs.append("モンスターは現れなかった。")
         return msgs


### PR DESCRIPTION
## Summary
- implement `MonsterBook` and sample entries
- track captured and seen monsters in Player
- mark enemies as seen when generating battle parties
- allow viewing monster encyclopedia from the main menu
- test recording captured monsters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412aa0666c8321b38e7a34418104a4