### PR TITLE
Add monster book page for web UI

### DIFF
--- a/templates/monster_book.html
+++ b/templates/monster_book.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>モンスター図鑑</h2>
+<p>発見率 {{ completion|round(1) }}%</p>
+<ul>
+{% for entry, status in entries %}
+  <li>
+  {% if status == 'captured' %}
+    <strong>{{ entry.monster_id }}</strong> [捕獲]<br>
+    {{ entry.description }}
+    {% if entry.location_hint %}<br>出現場所: {{ entry.location_hint }}{% endif %}
+    {% if entry.synthesis_hint %}<br>合成ヒント: {{ entry.synthesis_hint }}{% endif %}
+  {% elif status == 'seen' %}
+    {{ entry.monster_id }} [目撃]<br>
+    ??? 詳細は不明
+    {% if entry.location_hint %}<br>手掛かり: {{ entry.location_hint }}{% endif %}
+  {% else %}
+    ??? [未発見]
+  {% endif %}
+  </li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/play.html
+++ b/templates/play.html
@@ -14,6 +14,7 @@
 <form action="{{ url_for('party', user_id=user_id) }}" method="get"><button>パーティ</button></form>
 <form action="{{ url_for('explore', user_id=user_id) }}" method="post"><button>探索</button></form>
 <form action="{{ url_for('items', user_id=user_id) }}" method="get"><button>アイテム</button></form>
+<form action="{{ url_for('monster_book', user_id=user_id) }}" method="get"><button>図鑑</button></form>
 <form action="{{ url_for('world_map', user_id=user_id) }}" method="get"><button>マップ</button></form>
 {% if loc.has_shop %}
 <form action="{{ url_for('shop', user_id=user_id) }}" method="get"><button>ショップ</button></form>

--- a/web_main.py
+++ b/web_main.py
@@ -11,7 +11,7 @@ import random
 
 import database_setup
 from player import Player
-from monsters.monster_data import ALL_MONSTERS
+from monsters.monster_data import ALL_MONSTERS, MONSTER_BOOK_DATA
 from items.item_data import ALL_ITEMS
 from map_data import LOCATIONS, get_map_overview
 from exploration import generate_enemy_party
@@ -149,6 +149,28 @@ def party(user_id):
         return redirect(url_for('index'))
     return render_template("party.html", player=player, user_id=user_id)
 
+
+@app.route('/monster_book/<int:user_id>')
+def monster_book(user_id):
+    """Show the player's monster encyclopedia."""
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    entries = []
+    for mid, entry in MONSTER_BOOK_DATA.items():
+        status = 'unknown'
+        if mid in player.monster_book.captured:
+            status = 'captured'
+        elif mid in player.monster_book.seen:
+            status = 'seen'
+        entries.append((entry, status))
+    completion = player.monster_book.completion_rate()
+    return render_template(
+        'monster_book.html',
+        entries=entries,
+        completion=completion,
+        user_id=user_id,
+    )
 
 @app.route('/formation/<int:user_id>', methods=['GET', 'POST'])
 def formation(user_id):


### PR DESCRIPTION
## Summary
- add MONSTER_BOOK_DATA import to web_main
- implement /monster_book page and template
- link monster book from the play page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684142b19d04832192dd1c0ccd79c7c4