### PR TITLE
Add local monster images directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,7 @@ cython_debug/
 # Local database and caches
 monster_rpg_save.db
 __pycache__/
+
+# Monster images (local only)
+static/images/*
+!static/images/.gitkeep

--- a/README.md
+++ b/README.md
@@ -60,4 +60,7 @@ Other notable modules include `player.py` (player data and save/load logic), `ba
 ## Saving
 The game saves player data to `monster_rpg_save.db`. Only basic information is stored at the moment, but the structure is ready for expansion.
 
+## Monster Images
+Place monster pictures under `static/images/` on your local machine. The folder is kept in the repository via an empty `.gitkeep` file but ignored by Git so large image files do not get uploaded.
+
 Enjoy exploring the world and training your monsters!


### PR DESCRIPTION
## Summary
- ignore `static/images` except for `.gitkeep`
- document the local images directory in README
- add an empty `.gitkeep` file under `static/images/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415a595e8483219184d40e8406ea64