### PR TITLE
Handle duplicate username gracefully

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -1,5 +1,9 @@
 {% extends "layout.html" %}
 {% block content %}
 <p>{{ message }}</p>
+{% if user_id %}
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% else %}
+<a href="{{ url_for('index') }}">トップへ</a>
+{% endif %}
 {% endblock %}

--- a/web_main.py
+++ b/web_main.py
@@ -10,6 +10,7 @@ except ImportError as e:  # pragma: no cover - dependency check
 import random
 
 import database_setup
+import sqlite3
 from player import Player
 from monsters.monster_data import ALL_MONSTERS, MONSTER_BOOK_DATA
 from items.item_data import ALL_ITEMS
@@ -92,7 +93,11 @@ def index():
 def start_game():
     """Create a new player and start the game."""
     name = request.form.get('username', 'Hero')
-    user_id = database_setup.create_user(name, 'pw')
+    try:
+        user_id = database_setup.create_user(name, 'pw')
+    except sqlite3.IntegrityError:
+        msg = "既に同じ名前の人が存在しています"
+        return render_template('result.html', message=msg, user_id=None)
     player = Player(name=name, user_id=user_id, gold=100)
     for mid in ("slime", "goblin", "wolf"):
         if mid in ALL_MONSTERS:


### PR DESCRIPTION
## Summary
- display an error message when trying to start a game with a duplicate username
- allow `result.html` to link back to index if no user is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416f6aea1083218c925cda7fac7a37