### PR TITLE
Add simple battle screen

### DIFF
--- a/templates/battle.html
+++ b/templates/battle.html
@@ -1,0 +1,11 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>戦闘結果</h2>
+<ul>
+{% for m in messages %}
+  <li>{{ m }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}
+

--- a/templates/play.html
+++ b/templates/play.html
@@ -13,6 +13,7 @@
 <form action="{{ url_for('status', user_id=user_id) }}" method="get"><button>ステータス</button></form>
 <form action="{{ url_for('party', user_id=user_id) }}" method="get"><button>パーティ</button></form>
 <form action="{{ url_for('explore', user_id=user_id) }}" method="post"><button>探索</button></form>
+<form action="{{ url_for('battle', user_id=user_id) }}" method="post"><button>戦闘</button></form>
 <form action="{{ url_for('battle_log', user_id=user_id) }}" method="get"><button>バトルログ</button></form>
 <form action="{{ url_for('items', user_id=user_id) }}" method="get"><button>アイテム</button></form>
 <form action="{{ url_for('monster_book', user_id=user_id) }}" method="get"><button>図鑑</button></form>

--- a/web_main.py
+++ b/web_main.py
@@ -288,6 +288,19 @@ def explore(user_id):
     return render_template('explore.html', messages=messages, user_id=user_id)
 
 
+@app.route('/battle/<int:user_id>', methods=['POST'])
+def battle(user_id):
+    """Initiate a simple battle and show the result log."""
+    player = active_players.get(user_id)
+    if not player:
+        return redirect(url_for('index'))
+    loc = LOCATIONS.get(player.current_location_id)
+    if not loc:
+        return redirect(url_for('play', user_id=user_id))
+    messages = handle_battle(player, loc)
+    return render_template('battle.html', messages=messages, user_id=user_id)
+
+
 @app.route('/map/<int:user_id>')
 def world_map(user_id):
     player = active_players.get(user_id)


### PR DESCRIPTION
## Summary
- add `/battle` endpoint to begin a simple battle in the web UI
- show a "戦闘" button on the play page
- render battle results on new `battle.html` template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684174159a6c8321b89a0249b6556824