### PR TITLE
Add interactive web battle system

### DIFF
--- a/templates/battle_turn.html
+++ b/templates/battle_turn.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+{% block content %}
+<h2>Turn {{ battle.turn }}</h2>
+<h3>味方パーティ</h3>
+<ul>
+{% for m in player_party %}
+  <li>{{ m.name }} HP {{ m.hp }}/{{ m.max_hp }}{% if not m.is_alive %} (Down){% endif %}</li>
+{% endfor %}
+</ul>
+<h3>敵パーティ</h3>
+<ul>
+{% for e in enemy_party %}
+  <li>{{ e.name }} HP {{ e.hp }}/{{ e.max_hp }}{% if not e.is_alive %} (Down){% endif %}</li>
+{% endfor %}
+</ul>
+<form action="{{ url_for('battle', user_id=user_id) }}" method="post">
+{% for idx,m in enumerate(player_party) %}
+  {% if m.is_alive %}
+  <label>{{ m.name }} の攻撃対象:</label>
+  <select name="target_{{ idx }}">
+    {% for j,e in enumerate(enemy_party) %}
+      {% if e.is_alive %}
+      <option value="{{ j }}">{{ e.name }}</option>
+      {% endif %}
+    {% endfor %}
+  </select><br>
+  {% endif %}
+{% endfor %}
+  <button type="submit">行動</button>
+</form>
+<hr>
+<ul>
+{% for line in log %}
+  <li>{{ line }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+{% endblock %}

--- a/templates/play.html
+++ b/templates/play.html
@@ -13,7 +13,7 @@
 <form action="{{ url_for('status', user_id=user_id) }}" method="get"><button>ステータス</button></form>
 <form action="{{ url_for('party', user_id=user_id) }}" method="get"><button>パーティ</button></form>
 <form action="{{ url_for('explore', user_id=user_id) }}" method="post"><button>探索</button></form>
-<form action="{{ url_for('battle', user_id=user_id) }}" method="post"><button>戦闘</button></form>
+<form action="{{ url_for('battle', user_id=user_id) }}" method="get"><button>戦闘</button></form>
 <form action="{{ url_for('battle_log', user_id=user_id) }}" method="get"><button>バトルログ</button></form>
 <form action="{{ url_for('items', user_id=user_id) }}" method="get"><button>アイテム</button></form>
 <form action="{{ url_for('monster_book', user_id=user_id) }}" method="get"><button>図鑑</button></form>


### PR DESCRIPTION
## Summary
- implement a `Battle` class in `web_main.py` to store state across turns
- convert `/battle/<id>` route to run turn-based battles that persist on the server
- add `battle_turn.html` template for the new view
- update play page link to use the new battle interface
- auto battle (`run_simple_battle`) now uses the new `Battle` logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684178307370832198dd443d5891e96a