### PR TITLE
Show monster images if available

### DIFF
--- a/templates/monster_book.html
+++ b/templates/monster_book.html
@@ -4,13 +4,16 @@
   <h2 class="book-title">◆ モンスター図鑑 ◆</h2>
   <div class="book-meta">発見率 <span class="book-percent">{{ completion|round(1) }}%</span></div>
   <ul class="book-list">
-    {% for entry, status in entries %}
+    {% for entry, status, image_url in entries %}
       <li class="book-entry status-{{ status }}">
         {% if status == 'captured' %}
           <div class="entry-head">
             <span class="badge badge-captured">捕獲</span>
             <span class="entry-id">{{ entry.monster_id }}</span>
           </div>
+          {% if image_url %}
+            <div class="entry-img"><img src="{{ image_url }}" alt="{{ entry.monster_id }}"></div>
+          {% endif %}
           <div class="entry-desc">{{ entry.description }}</div>
           {% if entry.location_hint %}
             <div class="entry-hint"><span class="hint-label">出現場所：</span>{{ entry.location_hint }}</div>
@@ -23,6 +26,9 @@
             <span class="badge badge-seen">目撃</span>
             <span class="entry-id">{{ entry.monster_id }}</span>
           </div>
+          {% if image_url %}
+            <div class="entry-img"><img src="{{ image_url }}" alt="{{ entry.monster_id }}"></div>
+          {% endif %}
           <div class="entry-desc">？？？ 詳細は不明</div>
           {% if entry.location_hint %}
             <div class="entry-hint"><span class="hint-label">手掛かり：</span>{{ entry.location_hint }}</div>
@@ -137,6 +143,14 @@
   font-size: 1.08em;
   font-weight: 500;
   line-height: 1.6;
+}
+.entry-img {
+  text-align: center;
+  margin-bottom: 0.5em;
+}
+.entry-img img {
+  max-width: 100px;
+  height: auto;
 }
 .entry-hint {
   font-size: 0.99em;

--- a/web_main.py
+++ b/web_main.py
@@ -222,7 +222,12 @@ def monster_book(user_id):
             status = 'captured'
         elif mid in player.monster_book.seen:
             status = 'seen'
-        entries.append((entry, status))
+
+        image_url = None
+        monster_obj = ALL_MONSTERS.get(mid)
+        if monster_obj and monster_obj.image_filename:
+            image_url = url_for('static', filename=f"images/{monster_obj.image_filename}")
+        entries.append((entry, status, image_url))
     completion = player.monster_book.completion_rate()
     return render_template(
         'monster_book.html',


### PR DESCRIPTION
## Summary
- add image lookup to web monster book
- display images for captured or seen monsters when available
- style small monster images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684193ba2f4483218ca345b79eb8d414