### PR TITLE
Remove manual battle button from menu

### DIFF
--- a/templates/play.html
+++ b/templates/play.html
@@ -28,7 +28,6 @@
     <form action="{{ url_for('status', user_id=user_id) }}" method="get"><button class="menu-btn">ステータス</button></form>
     <form action="{{ url_for('party', user_id=user_id) }}" method="get"><button class="menu-btn">パーティ</button></form>
     <form action="{{ url_for('explore', user_id=user_id) }}" method="post"><button class="menu-btn">探索</button></form>
-    <form action="{{ url_for('battle', user_id=user_id) }}" method="get"><button class="menu-btn">戦闘</button></form>
     <form action="{{ url_for('battle_log', user_id=user_id) }}" method="get"><button class="menu-btn">バトルログ</button></form>
     <form action="{{ url_for('items', user_id=user_id) }}" method="get"><button class="menu-btn">アイテム</button></form>
     <form action="{{ url_for('monster_book', user_id=user_id) }}" method="get"><button class="menu-btn">図鑑</button></form>


### PR DESCRIPTION
## Summary
- tidy up the play screen by dropping the manual battle button
- exploring already starts fights automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841993401708321aba91ef8449ff11d