### PR TITLE
Improve exploration flow

### DIFF
--- a/templates/explore.html
+++ b/templates/explore.html
@@ -6,5 +6,41 @@
   <li>{{ m }}</li>
 {% endfor %}
 </ul>
+
+<div class="progress-container">
+  <div class="progress-bar">
+    <div class="progress-fill" style="width: {{ progress }}%"></div>
+  </div>
+  <span class="progress-percent">{{ progress }}%</span>
+</div>
+
+<form action="{{ url_for('explore', user_id=user_id) }}" method="post">
+  <button type="submit">さらに探索する</button>
+</form>
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
+
+<style>
+  .progress-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 12px 0;
+  }
+  .progress-bar {
+    width: 200px;
+    height: 16px;
+    background: #eee;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .progress-fill {
+    background: linear-gradient(90deg, #5fffc2, #5e92fa 70%);
+    height: 100%;
+  }
+  .progress-percent {
+    width: 50px;
+    text-align: right;
+    font-weight: bold;
+  }
+</style>
 {% endblock %}

--- a/web_main.py
+++ b/web_main.py
@@ -334,16 +334,24 @@ def explore(user_id):
     loc = LOCATIONS.get(player.current_location_id)
     if not loc:
         return redirect(url_for('play', user_id=user_id))
+
     messages = []
     before = player.get_exploration(player.current_location_id)
     gained = random.randint(15, 30)
     after = player.increase_exploration(player.current_location_id, gained)
     messages.append(f"探索度 {before}% -> {after}%")
+
     if loc.possible_enemies and random.random() < loc.encounter_rate:
         messages.extend(handle_battle(player, loc))
     else:
         messages.append('モンスターは現れなかった。')
-    return render_template('explore.html', messages=messages, user_id=user_id)
+
+    return render_template(
+        'explore.html',
+        messages=messages,
+        user_id=user_id,
+        progress=after,
+    )
 
 
 @app.route('/battle/<int:user_id>', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- keep player on the exploration page after exploring
- add progress bar and option to continue exploring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419a8fa62c8321afcc2fc1636abf07