### PR TITLE
Add reserve monster system with formation page improvements

### DIFF
--- a/database_setup.py
+++ b/database_setup.py
@@ -63,6 +63,16 @@ def initialize_database():
     )
     """)
 
+    # 控えモンスターを保存するテーブル
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS storage_monsters (
+        player_id INTEGER,
+        monster_id TEXT,
+        level INTEGER,
+        exp INTEGER
+    )
+    """)
+
     # player_items テーブルの作成
     cursor.execute("""
     CREATE TABLE IF NOT EXISTS player_items (

--- a/templates/formation.html
+++ b/templates/formation.html
@@ -1,9 +1,15 @@
 {% extends "layout.html" %}
 {% block content %}
 <h2>編成</h2>
+<h3>編成中</h3>
 <ul>
 {% for m in player.party_monsters %}
-  <li>{{ loop.index }}. {{ m.name }}
+  <li>
+    {% if m.image_filename %}
+      <img src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}" width="64">
+    {% else %}
+      {{ m.name }}
+    {% endif %}
     <form action="{{ url_for('formation', user_id=user_id) }}" method="post" style="display:inline">
       <input type="hidden" name="index" value="{{ loop.index0 }}">
       {% if not loop.first %}
@@ -12,9 +18,30 @@
       {% if not loop.last %}
       <button type="submit" name="move" value="down">↓</button>
       {% endif %}
+      <button type="submit" name="remove" value="1">外す</button>
     </form>
   </li>
 {% endfor %}
 </ul>
+<h3>未編成</h3>
+<ul>
+{% for m in player.reserve_monsters %}
+  <li>
+    <form action="{{ url_for('formation', user_id=user_id) }}" method="post" style="display:inline">
+      <input type="hidden" name="add_index" value="{{ loop.index0 }}">
+      <button type="submit" style="border:none;background:none;padding:0;">
+        {% if m.image_filename %}
+          <img src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}" width="64">
+        {% else %}
+          {{ m.name }}
+        {% endif %}
+      </button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+<form action="{{ url_for('formation', user_id=user_id) }}" method="post">
+  <button type="submit" name="reset" value="1">リセット</button>
+</form>
 <a href="{{ url_for('party', user_id=user_id) }}">戻る</a>
 {% endblock %}

--- a/web_main.py
+++ b/web_main.py
@@ -301,6 +301,17 @@ def formation(user_id):
             player.move_monster(idx, idx - 1)
         elif move == 'down':
             player.move_monster(idx, idx + 1)
+
+        if 'remove' in request.form:
+            player.move_to_reserve(idx)
+        if 'add_index' in request.form:
+            try:
+                add_idx = int(request.form.get('add_index'))
+                player.move_from_reserve(add_idx)
+            except (TypeError, ValueError):
+                pass
+        if 'reset' in request.form:
+            player.reset_formation()
     return render_template('formation.html', player=player, user_id=user_id)
 
 


### PR DESCRIPTION
## Summary
- create new `storage_monsters` table for unused monsters
- track `reserve_monsters` on `Player` to hold monsters outside the active formation
- save/load reserve monsters to the database
- add methods on `Player` to move monsters between active party and reserve and to reset the formation
- extend formation route to handle adding/removing/resetting monsters
- redesign `formation.html` to show active and reserve monsters with buttons

## Testing
- `pytest -q`
- `pytest tests/test_save_load.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6842228508808321af2d956aa5001e0a