### PR TITLE
Implement basic status effects and evolution conditions

### DIFF
--- a/monsters/evolution_rules.py
+++ b/monsters/evolution_rules.py
@@ -3,4 +3,12 @@
 EVOLUTION_RULES = {
     "dragon_pup": {"level": 10, "evolves_to": "ashen_drake"},
     "phoenix_chick": {"level": 8, "evolves_to": "cinder_sentinel"},
+    # スライムはヒールを覚えた状態でLv5になるとウォーターワルフに進化
+    "slime": {
+        "level": 5,
+        "evolves_to": "water_wolf",
+        "requires_skill": "ヒール",
+    },
+    # ウルフはLv7でシャドウパンサーへ進化
+    "wolf": {"level": 7, "evolves_to": "shadow_panther"},
 }

--- a/monsters/monster_class.py
+++ b/monsters/monster_class.py
@@ -180,6 +180,10 @@ class Monster:
             return
         if self.level < rule.get('level', 0):
             return
+        req_skill = rule.get('requires_skill')
+        if req_skill:
+            if not any(getattr(s, 'name', '') == req_skill for s in self.skills):
+                return
         from .monster_data import ALL_MONSTERS  # local import to avoid cycle
         new_id = rule.get('evolves_to')
         template = ALL_MONSTERS.get(new_id)

--- a/tests/test_status_effects.py
+++ b/tests/test_status_effects.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from battle import apply_skill_effect, process_status_effects
+from monsters.monster_class import Monster
+from skills.skills import ALL_SKILLS, Skill
+
+class StatusEffectTests(unittest.TestCase):
+    def test_poison_damage(self):
+        target = Monster('Target', hp=20, attack=5, defense=2)
+        attacker = Monster('Enemy', hp=20, attack=5, defense=2)
+        skill = Skill('TestPoison', power=0, cost=0, skill_type='status',
+                      effect='poison', target='enemy', duration=1)
+        apply_skill_effect(attacker, [target], skill)
+        self.assertTrue(any(e['name'] == 'poison' for e in target.status_effects))
+        process_status_effects(target)
+        self.assertEqual(target.hp, 18)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand monster evolution rules with skill requirement examples
- add status effect definitions and processing to battle flow
- allow debuff/status skills to apply effects
- update Monster class to check new evolution requirements
- test poison damage over time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422c6e44a08321b1d6564d876829cc