### PR TITLE
Add coordinate system for locations

### DIFF
--- a/map_data.py
+++ b/map_data.py
@@ -7,7 +7,7 @@ class Location:
                  inn_cost=0, hidden_connections=None, has_shop=False,
                  shop_items=None, shop_monsters=None, boss_enemy_id=None,
                  rare_enemies=None, treasure_items=None, event_chance=0.0,
-                 avg_enemy_level=1):
+                 avg_enemy_level=1, *, x: int = 0, y: int = 0):
         """
         場所の情報を保持するクラス。
         location_id (str): 場所を識別するユニークなID
@@ -36,6 +36,8 @@ class Location:
         self.treasure_items = treasure_items if treasure_items else []
         self.event_chance = event_chance
         self.avg_enemy_level = avg_enemy_level
+        self.x = x
+        self.y = y
 
     def get_random_enemy_id(self):
         """この場所で出現する可能性のあるモンスターIDをランダムに1つ返す。"""
@@ -57,7 +59,9 @@ LOCATIONS = {
         has_shop=True,
         shop_items={"small_potion": 15},
         shop_monsters={"slime": 50},
-        avg_enemy_level=1
+        avg_enemy_level=1,
+        x=0,
+        y=0
     ),
     "field_near_village": Location(
         location_id="field_near_village",
@@ -66,7 +70,9 @@ LOCATIONS = {
         connections={"南": "village_square", "北東": "forest_entrance"},
         possible_enemies=["slime"], # ALL_MONSTERSのキーで指定
         encounter_rate=0.6, # 60%の確率でエンカウント
-        avg_enemy_level=1
+        avg_enemy_level=1,
+        x=0,
+        y=1
     ),
     "forest_entrance": Location(
         location_id="forest_entrance",
@@ -75,7 +81,9 @@ LOCATIONS = {
         connections={"南西": "field_near_village", "奥へ": "deep_forest", "東": "mystic_lake"},
         possible_enemies=["goblin", "slime"],
         encounter_rate=0.75,
-        avg_enemy_level=2
+        avg_enemy_level=2,
+        x=1,
+        y=2
     ),
     "mystic_lake": Location(
         location_id="mystic_lake",
@@ -84,7 +92,9 @@ LOCATIONS = {
         connections={"西": "forest_entrance"},
         possible_enemies=["water_wolf", "forest_spirit"],
         encounter_rate=0.8,
-        avg_enemy_level=3
+        avg_enemy_level=3,
+        x=2,
+        y=2
     ),
     "deep_forest": Location(
         location_id="deep_forest",
@@ -98,7 +108,9 @@ LOCATIONS = {
         rare_enemies=["phoenix_chick"],
         treasure_items=["small_potion"],
         event_chance=0.3,
-        avg_enemy_level=4
+        avg_enemy_level=4,
+        x=1,
+        y=3
     ),
     "forest_boss_room": Location(
         location_id="forest_boss_room",
@@ -107,7 +119,9 @@ LOCATIONS = {
         connections={"奥地へ戻る": "deep_forest"},
         possible_enemies=["dragon_pup"],
         encounter_rate=1.0,
-        avg_enemy_level=5
+        avg_enemy_level=5,
+        x=1,
+        y=4
     ),
     "hill_road": Location(
     location_id="hill_road",
@@ -116,7 +130,9 @@ LOCATIONS = {
     connections={"南": "field_near_village", "北": "mountain_foothills"},
     possible_enemies=["wolf", "orc_warrior"],
     encounter_rate=0.55,
-    avg_enemy_level=3
+    avg_enemy_level=3,
+    x=0,
+    y=2
 ),
 
 "mountain_foothills": Location(
@@ -128,6 +144,8 @@ LOCATIONS = {
     encounter_rate=0.75,
     treasure_items=["medium_potion"],
     avg_enemy_level=4,
+    x=0,
+    y=3,
 ),
 
 "thunder_peak": Location(
@@ -141,6 +159,8 @@ LOCATIONS = {
     boss_enemy_id="storm_golem",
     treasure_items=["thunder_core"],
     avg_enemy_level=6,
+    x=0,
+    y=4,
 ),
 
 "ancient_ruins": Location(
@@ -152,6 +172,8 @@ LOCATIONS = {
     encounter_rate=0.7,
     event_chance=0.25,
     avg_enemy_level=5,
+    x=-1,
+    y=3,
 ),
 
 "catacombs_entrance": Location(
@@ -163,6 +185,8 @@ LOCATIONS = {
     encounter_rate=0.8,
     treasure_items=["frost_crystal"],
     avg_enemy_level=6,
+    x=-1,
+    y=3,
 ),
 
 "catacombs_deep": Location(
@@ -176,6 +200,8 @@ LOCATIONS = {
     rare_enemies=["abyss_watcher"],
     treasure_items=["abyss_shard"],
     avg_enemy_level=8,
+    x=-1,
+    y=4,
 ),
 
 "abyssal_chasm": Location(
@@ -186,6 +212,8 @@ LOCATIONS = {
     possible_enemies=["shadow_panther", "abyss_watcher", "blighted_knight"],
     encounter_rate=1.0,
     avg_enemy_level=9,
+    x=0,
+    y=5,
 ),
 
 "celestial_tower": Location(
@@ -202,6 +230,8 @@ LOCATIONS = {
     inn_cost=50,
     treasure_items=["celestial_feather", "elixir"],
     avg_enemy_level=10,
+    x=4,
+    y=5,
 ),
 "desert_outskirts": Location(
     location_id="desert_outskirts",
@@ -211,6 +241,8 @@ LOCATIONS = {
     possible_enemies=["desert_scorpion", "sand_wyrm"],
     encounter_rate=0.65,
     avg_enemy_level=4,
+    x=1,
+    y=1,
 ),
 
 "desert_oasis": Location(
@@ -223,6 +255,8 @@ LOCATIONS = {
     possible_enemies=["desert_scorpion"],
     encounter_rate=0.3,
     avg_enemy_level=3,
+    x=2,
+    y=1,
 ),
 
 "sunken_temple": Location(
@@ -234,6 +268,8 @@ LOCATIONS = {
     encounter_rate=0.85,
     treasure_items=["frost_crystal"],
     avg_enemy_level=7,
+    x=2,
+    y=2,
 ),
 
 "abyssal_marsh": Location(
@@ -244,6 +280,8 @@ LOCATIONS = {
     possible_enemies=["kraken", "blighted_knight", "abyss_watcher"],
     encounter_rate=0.95,
     avg_enemy_level=8,
+    x=3,
+    y=2,
 ),
 
 "volcanic_ridge": Location(
@@ -256,6 +294,8 @@ LOCATIONS = {
     rare_enemies=["cinder_sentinel"],
     treasure_items=["dragon_scale"],
     avg_enemy_level=9,
+    x=4,
+    y=2,
 ),
 
 "lava_core": Location(
@@ -267,6 +307,8 @@ LOCATIONS = {
     possible_enemies=["lava_elemental"],
     encounter_rate=1.0,
     avg_enemy_level=10,
+    x=4,
+    y=3,
 ),
 
 "sky_isle": Location(
@@ -278,6 +320,8 @@ LOCATIONS = {
     encounter_rate=0.8,
     hidden_connections={"更なる空の高みへ": "sky_isle_inner_sanctum"},
     avg_enemy_level=10,
+    x=4,
+    y=4,
 ),
 
 "sky_isle_inner_sanctum": Location(
@@ -290,6 +334,8 @@ LOCATIONS = {
     encounter_rate=1.0,
     treasure_items=["celestial_feather", "elixir"],
     avg_enemy_level=12,
+    x=5,
+    y=4,
 )
 # ------------------------------------------------------------
 # ▼ ここまで追加マップ
@@ -311,7 +357,8 @@ def get_map_overview() -> str:
             dest_name = dest.name if dest else dest_id
             conn_parts.append(f"{cmd}->{dest_name}")
         conn_text = ", ".join(conn_parts) if conn_parts else "なし"
-        lines.append(f"{loc.name}: {conn_text}")
+        coord_text = f"({loc.x},{loc.y})"
+        lines.append(f"{loc.name}{coord_text}: {conn_text}")
     return "\n".join(lines)
 
 

--- a/tests/test_map_display.py
+++ b/tests/test_map_display.py
@@ -9,7 +9,9 @@ from map_data import get_map_overview, LOCATIONS
 class MapDisplayTests(unittest.TestCase):
     def test_overview_contains_start(self):
         overview = get_map_overview()
-        self.assertIn(LOCATIONS["village_square"].name, overview)
+        loc = LOCATIONS["village_square"]
+        self.assertIn(loc.name, overview)
+        self.assertIn(f"({loc.x},{loc.y})", overview)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `Location` with `x` and `y` coordinates
- assign coordinates to all defined locations
- show coordinates in map overview output
- update tests for new coordinate display

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842501a76dc832187152518cf38c816