### PR TITLE
Add coordinates to locations

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -22,7 +22,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 1
+    "avg_enemy_level": 1,
+    "x": 0,
+    "y": 0
   },
   "field_near_village": {
     "location_id": "field_near_village",
@@ -46,7 +48,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 1
+    "avg_enemy_level": 1,
+    "x": 1,
+    "y": 0
   },
   "forest_entrance": {
     "location_id": "forest_entrance",
@@ -72,7 +76,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 2
+    "avg_enemy_level": 2,
+    "x": 2,
+    "y": 0
   },
   "mystic_lake": {
     "location_id": "mystic_lake",
@@ -96,7 +102,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 3
+    "avg_enemy_level": 3,
+    "x": 3,
+    "y": 0
   },
   "deep_forest": {
     "location_id": "deep_forest",
@@ -127,7 +135,9 @@
       "small_potion"
     ],
     "event_chance": 0.3,
-    "avg_enemy_level": 4
+    "avg_enemy_level": 4,
+    "x": 4,
+    "y": 0
   },
   "forest_boss_room": {
     "location_id": "forest_boss_room",
@@ -150,7 +160,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 5
+    "avg_enemy_level": 5,
+    "x": 0,
+    "y": 1
   },
   "hill_road": {
     "location_id": "hill_road",
@@ -175,7 +187,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 3
+    "avg_enemy_level": 3,
+    "x": 1,
+    "y": 1
   },
   "mountain_foothills": {
     "location_id": "mountain_foothills",
@@ -204,7 +218,9 @@
       "medium_potion"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 4
+    "avg_enemy_level": 4,
+    "x": 2,
+    "y": 1
   },
   "thunder_peak": {
     "location_id": "thunder_peak",
@@ -232,7 +248,9 @@
       "thunder_core"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 6
+    "avg_enemy_level": 6,
+    "x": 3,
+    "y": 1
   },
   "ancient_ruins": {
     "location_id": "ancient_ruins",
@@ -258,7 +276,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.25,
-    "avg_enemy_level": 5
+    "avg_enemy_level": 5,
+    "x": 4,
+    "y": 1
   },
   "catacombs_entrance": {
     "location_id": "catacombs_entrance",
@@ -286,7 +306,9 @@
       "frost_crystal"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 6
+    "avg_enemy_level": 6,
+    "x": 0,
+    "y": 2
   },
   "catacombs_deep": {
     "location_id": "catacombs_deep",
@@ -315,7 +337,9 @@
       "abyss_shard"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 8
+    "avg_enemy_level": 8,
+    "x": 1,
+    "y": 2
   },
   "abyssal_chasm": {
     "location_id": "abyssal_chasm",
@@ -341,7 +365,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 9
+    "avg_enemy_level": 9,
+    "x": 2,
+    "y": 2
   },
   "celestial_tower": {
     "location_id": "celestial_tower",
@@ -372,7 +398,9 @@
       "elixir"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 10
+    "avg_enemy_level": 10,
+    "x": 3,
+    "y": 2
   },
   "desert_outskirts": {
     "location_id": "desert_outskirts",
@@ -397,7 +425,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 4
+    "avg_enemy_level": 4,
+    "x": 4,
+    "y": 2
   },
   "desert_oasis": {
     "location_id": "desert_oasis",
@@ -424,7 +454,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 3
+    "avg_enemy_level": 3,
+    "x": 0,
+    "y": 3
   },
   "sunken_temple": {
     "location_id": "sunken_temple",
@@ -452,7 +484,9 @@
       "frost_crystal"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 7
+    "avg_enemy_level": 7,
+    "x": 1,
+    "y": 3
   },
   "abyssal_marsh": {
     "location_id": "abyssal_marsh",
@@ -478,7 +512,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 8
+    "avg_enemy_level": 8,
+    "x": 2,
+    "y": 3
   },
   "volcanic_ridge": {
     "location_id": "volcanic_ridge",
@@ -508,7 +544,9 @@
       "dragon_scale"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 9
+    "avg_enemy_level": 9,
+    "x": 3,
+    "y": 3
   },
   "lava_core": {
     "location_id": "lava_core",
@@ -532,7 +570,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 10
+    "avg_enemy_level": 10,
+    "x": 4,
+    "y": 3
   },
   "sky_isle": {
     "location_id": "sky_isle",
@@ -560,7 +600,9 @@
     "rare_enemies": [],
     "treasure_items": [],
     "event_chance": 0.0,
-    "avg_enemy_level": 10
+    "avg_enemy_level": 10,
+    "x": 0,
+    "y": 4
   },
   "sky_isle_inner_sanctum": {
     "location_id": "sky_isle_inner_sanctum",
@@ -586,6 +628,8 @@
       "elixir"
     ],
     "event_chance": 0.0,
-    "avg_enemy_level": 12
+    "avg_enemy_level": 12,
+    "x": 1,
+    "y": 4
   }
 }

--- a/map_data.py
+++ b/map_data.py
@@ -4,12 +4,28 @@ import os
 import random  # エンカウント判定で使います
 
 class Location:
-    def __init__(self, location_id, name, description, connections=None,
-                 possible_enemies=None, encounter_rate=0.0, has_inn=False,
-                 inn_cost=0, hidden_connections=None, has_shop=False,
-                 shop_items=None, shop_monsters=None, boss_enemy_id=None,
-                 rare_enemies=None, treasure_items=None, event_chance=0.0,
-                 avg_enemy_level=1):
+    def __init__(
+        self,
+        location_id,
+        name,
+        description,
+        connections=None,
+        possible_enemies=None,
+        encounter_rate=0.0,
+        has_inn=False,
+        inn_cost=0,
+        hidden_connections=None,
+        has_shop=False,
+        shop_items=None,
+        shop_monsters=None,
+        boss_enemy_id=None,
+        rare_enemies=None,
+        treasure_items=None,
+        event_chance=0.0,
+        avg_enemy_level=1,
+        x: int = 0,
+        y: int = 0,
+    ):
         """
         場所の情報を保持するクラス。
         location_id (str): 場所を識別するユニークなID
@@ -20,6 +36,7 @@ class Location:
         possible_enemies (list): その場所で出現する可能性のあるモンスターのID (ALL_MONSTERSのキー)のリスト。
                                  例: ["slime", "goblin"]
         encounter_rate (float): その場所でのエンカウント率 (0.0 から 1.0)。0ならエンカウントしない。
+        x, y (int): ワールドマップ上の座標。未指定なら 0,0。
         """
         self.location_id = location_id
         self.name = name
@@ -38,6 +55,8 @@ class Location:
         self.treasure_items = treasure_items if treasure_items else []
         self.event_chance = event_chance
         self.avg_enemy_level = avg_enemy_level
+        self.x = x
+        self.y = y
 
     def get_random_enemy_id(self):
         """この場所で出現する可能性のあるモンスターIDをランダムに1つ返す。"""
@@ -81,6 +100,8 @@ def load_locations(filepath: str | None = None) -> None:
             treasure_items=attrs.get("treasure_items"),
             event_chance=attrs.get("event_chance", 0.0),
             avg_enemy_level=attrs.get("avg_enemy_level", 1),
+            x=attrs.get("x", 0),
+            y=attrs.get("y", 0),
         )
         loaded[loc_id] = loc
 
@@ -100,7 +121,7 @@ def get_map_overview() -> str:
             dest_name = dest.name if dest else dest_id
             conn_parts.append(f"{cmd}->{dest_name}")
         conn_text = ", ".join(conn_parts) if conn_parts else "なし"
-        lines.append(f"{loc.name}: {conn_text}")
+        lines.append(f"{loc.name}({loc.x},{loc.y}): {conn_text}")
     return "\n".join(lines)
 
 

--- a/tests/test_map_display.py
+++ b/tests/test_map_display.py
@@ -10,7 +10,10 @@ class MapDisplayTests(unittest.TestCase):
     def test_overview_contains_start(self):
         load_locations()
         overview = get_map_overview()
-        self.assertIn(LOCATIONS["village_square"].name, overview)
+        start = LOCATIONS["village_square"]
+        self.assertIn(start.name, overview)
+        coord_text = f"({start.x},{start.y})"
+        self.assertIn(coord_text, overview)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `x`/`y` attributes to `Location`
- load coordinates from `locations.json`
- display coordinates in `get_map_overview`
- update map overview test to assert coordinates
- include coordinates for each location in `locations.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684251d58de48321a75190c1681b67dd