### PR TITLE
Add weighted enemy selection to locations

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -65,6 +65,10 @@
       "goblin",
       "slime"
     ],
+    "enemy_weights": {
+      "goblin": 0.7,
+      "slime": 0.3
+    },
     "encounter_rate": 0.75,
     "has_inn": false,
     "inn_cost": 0,

--- a/exploration.py
+++ b/exploration.py
@@ -46,7 +46,9 @@ def generate_enemy_party(location: Location, player=None) -> list[Monster]:
     base_level = getattr(location, "avg_enemy_level", 1)
 
     for _ in range(num_enemies):
-        enemy_id = random.choice(location.possible_enemies)
+        enemy_id = location.get_random_enemy_id()
+        if not enemy_id:
+            enemy_id = random.choice(location.possible_enemies)
         enemy_instance = get_monster_instance_copy(enemy_id)
         if enemy_instance:
             if player is not None and hasattr(player, "monster_book"):
@@ -57,7 +59,7 @@ def generate_enemy_party(location: Location, player=None) -> list[Monster]:
             enemy_party.append(enemy_instance)
 
     if not enemy_party and location.possible_enemies:
-        enemy_id = random.choice(location.possible_enemies)
+        enemy_id = location.get_random_enemy_id() or random.choice(location.possible_enemies)
         enemy_instance = get_monster_instance_copy(enemy_id)
         if enemy_instance:
             if player is not None and hasattr(player, "monster_book"):

--- a/map_data.py
+++ b/map_data.py
@@ -23,6 +23,7 @@ class Location:
         treasure_items=None,
         event_chance=0.0,
         avg_enemy_level=1,
+        enemy_weights: dict[str, float] | None = None,
         x: int = 0,
         y: int = 0,
     ):
@@ -57,9 +58,18 @@ class Location:
         self.avg_enemy_level = avg_enemy_level
         self.x = x
         self.y = y
+        self.enemy_weights = enemy_weights
 
     def get_random_enemy_id(self):
         """この場所で出現する可能性のあるモンスターIDをランダムに1つ返す。"""
+        if self.enemy_weights:
+            total = sum(self.enemy_weights.values())
+            r = random.random() * total
+            cum = 0.0
+            for enemy_id, weight in self.enemy_weights.items():
+                cum += weight
+                if r < cum:
+                    return enemy_id
         if self.possible_enemies:
             return random.choice(self.possible_enemies)
         return None
@@ -100,6 +110,7 @@ def load_locations(filepath: str | None = None) -> None:
             treasure_items=attrs.get("treasure_items"),
             event_chance=attrs.get("event_chance", 0.0),
             avg_enemy_level=attrs.get("avg_enemy_level", 1),
+            enemy_weights=attrs.get("enemy_weights"),
             x=attrs.get("x", 0),
             y=attrs.get("y", 0),
         )

--- a/tests/test_enemy_weights.py
+++ b/tests/test_enemy_weights.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import random
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from map_data import load_locations, LOCATIONS
+
+class EnemyWeightSelectionTests(unittest.TestCase):
+    def test_weighted_selection_deterministic(self):
+        load_locations()
+        loc = LOCATIONS['forest_entrance']
+        random.seed(0)
+        self.assertEqual(loc.get_random_enemy_id(), 'slime')
+        random.seed(1)
+        self.assertEqual(loc.get_random_enemy_id(), 'goblin')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `enemy_weights` property to `Location`
- choose enemy by weights in `get_random_enemy_id`
- use `get_random_enemy_id` when generating enemy parties
- allow enemy weights in location JSON data
- provide example weights for `forest_entrance`
- test weighted enemy selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684253c96ed08321a55d69f405beeda8