### PR TITLE
Implement grid-based world map view

### DIFF
--- a/map_data.py
+++ b/map_data.py
@@ -136,6 +136,28 @@ def get_map_overview() -> str:
     return "\n".join(lines)
 
 
+def get_map_grid() -> list[list[Location | None]]:
+    """LOCATIONS の座標から2次元グリッドを生成して返す"""
+    if not LOCATIONS:
+        return []
+
+    xs = [loc.x for loc in LOCATIONS.values()]
+    ys = [loc.y for loc in LOCATIONS.values()]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
+
+    width = max_x - min_x + 1
+    height = max_y - min_y + 1
+    grid: list[list[Location | None]] = [
+        [None for _ in range(width)] for _ in range(height)
+    ]
+
+    for loc in LOCATIONS.values():
+        grid[loc.y - min_y][loc.x - min_x] = loc
+
+    return grid
+
+
 def display_map() -> None:
     """ワールドマップを表示する"""
     print("===== ワールドマップ =====")

--- a/templates/map.html
+++ b/templates/map.html
@@ -3,7 +3,19 @@
 <div class="map-container">
   <h2>ワールドマップ</h2>
   <div class="map-overview">
-    <pre>{{ overview }}</pre>
+    <table class="map-grid">
+      {% for row in map_grid %}
+        <tr>
+          {% for cell in row %}
+            {% if cell %}
+              <td class="map-cell {% if current_loc_id == cell.location_id %}current{% endif %}">{{ cell.name }}</td>
+            {% else %}
+              <td class="map-cell empty"></td>
+            {% endif %}
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </table>
   </div>
   <h3>探索度</h3>
   <ul class="progress-list">
@@ -33,17 +45,26 @@
     padding: 24px 22px 32px 22px;
     text-align: center;
   }
-  .map-overview pre {
-    font-family: "Consolas", "Menlo", monospace;
-    font-size: 1.1rem;
+  .map-grid {
+    margin: 12px auto 24px auto;
+    border-collapse: collapse;
+  }
+  .map-cell {
+    width: 80px;
+    height: 60px;
+    border: 1px solid #cbd2ff;
     background: #e9eefa;
-    padding: 14px;
-    border-radius: 12px;
-    box-shadow: 0 1px 8px #a0a9ff2c;
-    margin-bottom: 24px;
-    margin-top: 12px;
-    overflow-x: auto;
-    text-align: left;
+    font-size: 0.9rem;
+    padding: 4px;
+    text-align: center;
+  }
+  .map-cell.empty {
+    background: none;
+    border: none;
+  }
+  .map-cell.current {
+    background: #ffe8b6;
+    font-weight: bold;
   }
   h2, h3 {
     color: #2d355e;

--- a/tests/test_map_display.py
+++ b/tests/test_map_display.py
@@ -4,7 +4,7 @@ import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from map_data import get_map_overview, LOCATIONS, load_locations
+from map_data import get_map_overview, get_map_grid, LOCATIONS, load_locations
 
 class MapDisplayTests(unittest.TestCase):
     def test_overview_contains_start(self):
@@ -14,6 +14,12 @@ class MapDisplayTests(unittest.TestCase):
         self.assertIn(start.name, overview)
         coord_text = f"({start.x},{start.y})"
         self.assertIn(coord_text, overview)
+
+    def test_grid_includes_start(self):
+        load_locations()
+        grid = get_map_grid()
+        ids = [cell.location_id for row in grid for cell in row if cell]
+        self.assertIn("village_square", ids)
 
 if __name__ == '__main__':
     unittest.main()

--- a/web_main.py
+++ b/web_main.py
@@ -14,7 +14,7 @@ import sqlite3
 from player import Player
 from monsters.monster_data import ALL_MONSTERS, MONSTER_BOOK_DATA
 from items.item_data import ALL_ITEMS
-from map_data import LOCATIONS, get_map_overview, load_locations
+from map_data import LOCATIONS, get_map_overview, get_map_grid, load_locations
 from exploration import generate_enemy_party
 
 app = Flask(__name__)
@@ -536,7 +536,16 @@ def world_map(user_id):
     if not player:
         return redirect(url_for('index'))
     overview = get_map_overview()
-    return render_template('map.html', overview=overview, progress=player.exploration_progress, locations=LOCATIONS, user_id=user_id)
+    map_grid = get_map_grid()
+    return render_template(
+        'map.html',
+        overview=overview,
+        progress=player.exploration_progress,
+        locations=LOCATIONS,
+        user_id=user_id,
+        map_grid=map_grid,
+        current_loc_id=player.current_location_id,
+    )
 
 
 @app.route('/battle_log/<int:user_id>')


### PR DESCRIPTION
## Summary
- add `get_map_grid` helper for 2D map structure
- switch map page to use a grid layout and highlight the player's location
- expose the grid in `world_map` route
- test the new helper with an updated map display test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425a9f08548321ae08d1896d1617fa