### PR TITLE
Implement scouting in web battles

### DIFF
--- a/templates/battle_turn.html
+++ b/templates/battle_turn.html
@@ -268,6 +268,7 @@ button:hover { background: #003c88; }
                     {% for s_idx, sk in enumerate(m.skills) %}
                     <option value="skill{{ s_idx }}" data-target="{{ sk.target }}" data-scope="{{ sk.scope }}">{{ sk.name }}</option>
                     {% endfor %}
+                    <option value="scout" data-target="enemy" data-scope="single">スカウト</option>
                     <option value="run" data-target="none" data-scope="none">逃げる</option>
                 </select>
                 <div>


### PR DESCRIPTION
## Summary
- support web battle scouts
- add scout option to battle UI
- keep Player reference in Battle class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842747b383883219ec6013ae8578148