### PR TITLE
Add template extension blocks

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>{{ title or "Monster RPG" }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  {% block head_extra %}{% endblock %}
 </head>
 <body>
   <header>
@@ -12,5 +13,6 @@
   <main>
     {% block content %}{% endblock %}
   </main>
+  {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow templates to inject extra head markup and scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68427d4343e08321be3e601d30c3dea7