### PR TITLE
Handle duplicate web users

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -25,13 +25,15 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
    pip install -r requirements.txt
    python webapp.py
    ```
+   `webapp.py` exposes only a couple JSON endpoints (like `/new_game` and
+   `/load_game`) and does not include the battle system.
 5. Another web interface exists in `web_main.py`:
    ```bash
    pip install -r requirements.txt
    python web_main.py
    ```
-   This starts the server at <http://localhost:5000/> and now uses
-   Flask templates for a slightly nicer appearance.
+   This starts the server at <http://localhost:5000/> using Flask templates
+   and provides the full game including battles.
 
 ## Project Structure
 

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -25,12 +25,13 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
    pip install -r requirements.txt
    python webapp.py
    ```
+   `webapp.py` は `/new_game` や `/load_game` といった最低限のJSON APIのみを提供し、戦闘機能は含まれていません。
 5. `web_main.py` でも別のウェブインターフェースを利用できます:
    ```bash
    pip install -r requirements.txt
    python web_main.py
    ```
-   これにより <http://localhost:5000/> でサーバーが起動し、Flaskテンプレートを使用した少し見やすい表示になります。
+   これにより <http://localhost:5000/> でサーバーが起動し、Flaskテンプレートを使用した画面で戦闘を含む完全なゲームを楽しめます。
 
 ## プロジェクト構成
 


### PR DESCRIPTION
## Summary
- catch IntegrityError when creating a user via the web API
- return a 409 error if username already exists
- document difference between `webapp.py` and `web_main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dfd70f2c83219d742201a0195ca9