### PR TITLE
Add start script for web version

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -27,10 +27,10 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
    ```
    `webapp.py` exposes only a couple JSON endpoints (like `/new_game` and
    `/load_game`) and does not include the battle system.
-5. Another web interface exists in `web_main.py`:
+5. Another web interface exists. Use the provided launcher script:
    ```bash
    pip install -r requirements.txt
-   python web_main.py
+   python start_rpg.py
    ```
    This starts the server at <http://localhost:5000/> using Flask templates
    and provides the full game including battles.

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -26,10 +26,10 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
    python webapp.py
    ```
    `webapp.py` は `/new_game` や `/load_game` といった最低限のJSON APIのみを提供し、戦闘機能は含まれていません。
-5. `web_main.py` でも別のウェブインターフェースを利用できます:
+5. `start_rpg.py` を使うと、完全なウェブ版を起動できます:
    ```bash
    pip install -r requirements.txt
-   python web_main.py
+   python start_rpg.py
    ```
    これにより <http://localhost:5000/> でサーバーが起動し、Flaskテンプレートを使用した画面で戦闘を含む完全なゲームを楽しめます。
 

--- a/start_rpg.py
+++ b/start_rpg.py
@@ -1,0 +1,6 @@
+"""Convenience script to launch the Monster RPG web interface."""
+
+from web_main import app
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add `start_rpg.py` to run the Flask web app
- update English and Japanese README instructions to use the new launcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e19e43308321b83b5c72927d2943