### PR TITLE
Fix AJAX post URL in battle turn page

### DIFF
--- a/templates/battle_turn.html
+++ b/templates/battle_turn.html
@@ -355,7 +355,8 @@ function setupBattleUI() {
         form.addEventListener('submit', evt => {
             evt.preventDefault();
             const formData = new FormData(form);
-            fetch(form.action, { method: 'POST', body: formData })
+            const postUrl = "{{ url_for('battle', user_id=user_id) }}";
+            fetch(postUrl, { method: 'POST', body: formData })
                 .then(resp => resp.text())
                 .then(html => {
                     if (html.includes('container-battle')) {


### PR DESCRIPTION
## Summary
- battle_turn.html: don't rely on form.action which might get modified
- embed the battle URL directly via Jinja and use it for the fetch request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e821206c832186b38f2b67adf3b5