### PR TITLE
Switch battle to JSON API

### DIFF
--- a/templates/battle_turn.html
+++ b/templates/battle_turn.html
@@ -357,28 +357,57 @@ function setupBattleUI() {
             const formData = new FormData(form);
             const postUrl = "{{ url_for('battle', user_id=user_id) }}";
             fetch(postUrl, { method: 'POST', body: formData })
-                .then(resp => resp.text())
-                .then(html => {
-                    if (html.includes('container-battle')) {
-                        const parser = new DOMParser();
-                        const doc = parser.parseFromString(html, 'text/html');
-                        const newCont = doc.querySelector('.container-battle');
-                        if (newCont) {
-                            document.querySelector('.container-battle').replaceWith(newCont);
-                            setupBattleUI();
-                        } else {
-                            document.open();
-                            document.write(html);
-                            document.close();
-                        }
-                    } else {
+                .then(resp => resp.json())
+                .then(data => {
+                    if (data.finished) {
                         document.open();
-                        document.write(html);
+                        document.write(data.html);
                         document.close();
+                        return;
                     }
+                    applyBattleData(data);
                 });
         });
     }
+}
+
+function applyBattleData(data) {
+    const allyUnits = document.querySelectorAll('.ally-party-display .battle-unit');
+    data.hp_values.player.forEach((info, idx) => {
+        const unit = allyUnits[idx];
+        if (!unit) return;
+        if (!info.alive) unit.classList.add('down');
+        const fill = unit.querySelector('.hp-fill');
+        const pct = Math.round(info.hp / info.max_hp * 100);
+        if (fill) fill.style.width = pct + '%';
+        const text = unit.querySelector('.hp-text');
+        if (text) text.textContent = info.hp + '/' + info.max_hp;
+    });
+
+    const enemyUnits = document.querySelectorAll('.enemy-area .battle-unit');
+    data.hp_values.enemy.forEach((info, idx) => {
+        const unit = enemyUnits[idx];
+        if (!unit) return;
+        if (!info.alive) unit.classList.add('down');
+        const fill = unit.querySelector('.hp-fill');
+        const pct = Math.round(info.hp / info.max_hp * 100);
+        if (fill) fill.style.width = pct + '%';
+        const text = unit.querySelector('.hp-text');
+        if (text) text.textContent = info.hp + '/' + info.max_hp;
+    });
+
+    const logEl = document.querySelector('.log');
+    if (logEl) {
+        logEl.innerHTML = '';
+        data.log.forEach(line => {
+            const li = document.createElement('li');
+            li.textContent = line;
+            logEl.appendChild(li);
+        });
+    }
+
+    const banner = document.querySelector('.turn-banner');
+    if (banner) banner.textContent = 'Turn ' + data.turn;
 }
 
 document.addEventListener('DOMContentLoaded', setupBattleUI);

--- a/tests/test_web_battle_json.py
+++ b/tests/test_web_battle_json.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import database_setup
+from web_main import app, Battle, active_battles
+from player import Player
+from monsters.monster_class import Monster
+
+class BattleViewJsonTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_web.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.user_id = database_setup.create_user('tester', 'pw')
+        self.client = app.test_client()
+        player = Player('Tester', user_id=self.user_id)
+        hero = Monster('Hero', hp=20, attack=5, defense=2)
+        player.party_monsters.append(hero)
+        enemy = Monster('Slime', hp=10, attack=3, defense=1)
+        battle_obj = Battle(player.party_monsters, [enemy], player)
+        active_battles[self.user_id] = battle_obj
+
+    def tearDown(self):
+        active_battles.pop(self.user_id, None)
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_post_returns_json(self):
+        resp = self.client.post(f'/battle/{self.user_id}', data={'action': 'attack', 'target_enemy': 0})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIsInstance(data, dict)
+        self.assertIn('hp_values', data)
+        self.assertIn('log', data)
+        self.assertIn('finished', data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- return JSON from the battle view when POSTing commands
- update `battle_turn.html` to consume JSON updates and modify the DOM
- add a regression test for the new JSON structure

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684791a42284832184e2eddbc8b3ac54