### PR TITLE
Enhance battle log visuals

### DIFF
--- a/src/monster_rpg/static/styles.css
+++ b/src/monster_rpg/static/styles.css
@@ -14,3 +14,31 @@ main {
 button {
     margin-top: 0.5rem;
 }
+
+/* Battle log styles */
+.battle-log p,
+ul.log li {
+    margin: 5px 0;
+    transition: all 0.3s ease;
+}
+
+.log-message-player_damage {
+    color: #ff4d4d;
+    font-weight: bold;
+    font-size: 1.1em;
+    animation: damage-flash 0.6s ease-out;
+}
+
+.log-message-player_attack {
+    color: #ffffff;
+}
+
+.log-message-info {
+    color: #a0a0a0;
+}
+
+@keyframes damage-flash {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); text-shadow: 0 0 8px rgba(255,255,255,0.8); }
+    100% { transform: scale(1); }
+}

--- a/src/monster_rpg/templates/battle.html
+++ b/src/monster_rpg/templates/battle.html
@@ -3,7 +3,7 @@
 <h2>戦闘結果</h2>
 <ul>
 {% for m in messages %}
-  <li>{{ m }}</li>
+  <li class="log-message-{{ m.type }}">{{ m.message }}</li>
 {% endfor %}
 </ul>
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>

--- a/src/monster_rpg/templates/battle_log.html
+++ b/src/monster_rpg/templates/battle_log.html
@@ -3,7 +3,7 @@
 <h2>最新のバトルログ</h2>
 <ul>
 {% for m in log %}
-  <li>{{ m }}</li>
+  <li class="log-message-{{ m.type }}">{{ m.message }}</li>
 {% endfor %}
 </ul>
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>

--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -248,8 +248,8 @@ button:hover { background: #004cd1; }
         </div>
 
         <ul class="log">
-            {% for line in log %}
-            <li>{{ line }}</li>
+            {% for entry in log %}
+            <li class="log-message-{{ entry.type }}">{{ entry.message }}</li>
             {% endfor %}
         </ul>
 
@@ -399,9 +399,10 @@ function applyBattleData(data) {
     const logEl = document.querySelector('.log');
     if (logEl) {
         logEl.innerHTML = '';
-        data.log.forEach(line => {
+        data.log.forEach(entry => {
             const li = document.createElement('li');
-            li.textContent = line;
+            li.textContent = entry.message;
+            li.className = 'log-message-' + entry.type;
             logEl.appendChild(li);
         });
     }


### PR DESCRIPTION
## Summary
- enable structured battle logs with message types
- style battle logs using CSS animations
- highlight logs in battle HTML templates

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847aab6b6808321932054f62b490298