### PR TITLE
Refactor skill effects into new module

### DIFF
--- a/src/monster_rpg/battle.py
+++ b/src/monster_rpg/battle.py
@@ -3,6 +3,11 @@ import random
 from .player import Player  # Playerクラスは直接使わないが、型ヒントなどで参照される可能性を考慮
 from .monsters import Monster, ALL_MONSTERS  # MonsterクラスとALL_MONSTERSを参照
 from .skills.skills import Skill  # Skillクラスを参照
+from .skills.skill_actions import (
+    simple_attack,
+    simple_heal,
+    SKILL_EFFECT_MAP,
+)
 # import traceback # デバッグ時に必要なら再度有効化
 
 # 属性相性倍率定義
@@ -113,79 +118,40 @@ def apply_skill_effect(caster: Monster, targets: list[Monster], skill_obj: Skill
             targets_to_use = [m for m in all_enemies if m.is_alive]
 
     for target in targets_to_use:  # スキルは複数の対象に影響することがある
-        if not target.is_alive: # 対象が既に倒れていたらスキップ
+        if not target.is_alive:  # 対象が既に倒れていたらスキップ
             print(f"{target.name} は既に倒れているため、{skill_obj.name} の効果を受けなかった。")
             continue
 
         if skill_obj.skill_type == "attack":
-            damage = skill_obj.power
-            actual_damage = max(1, damage - target.defense)
-            target.hp -= actual_damage
-            print(f"{target.name} に {actual_damage} のダメージ！ (残りHP: {max(0, target.hp)})")
-            if target.hp <= 0:
-                target.is_alive = False
-                print(f"{target.name} は倒れた！")
-            if isinstance(skill_obj.effect, str):
-                apply_status(target, skill_obj.effect)
+            simple_attack(caster, target, skill_obj.power)
 
-        elif skill_obj.skill_type == "heal":
-            if skill_obj.target == "ally":
-                original_hp = target.hp
-                target.hp += skill_obj.power
-                target.hp = min(target.hp, target.max_hp)
-                healed_amount = target.hp - original_hp
-                print(f"{target.name} のHPが {healed_amount} 回復した！ (現在HP: {target.hp})")
+        elif skill_obj.skill_type == "heal" and skill_obj.target == "ally":
+            simple_heal(target, skill_obj.power)
 
-        elif skill_obj.skill_type == "buff":
-            if skill_obj.target == "ally":
-                # effect が関数ならそれを実行、文字列の場合は簡易的なバフを実装
-                if callable(skill_obj.effect):
-                    try:
-                        remove_func = skill_obj.effect(target)
-                        if skill_obj.duration > 0:
-                            target.status_effects.append({
-                                "name": skill_obj.name,
-                                "remaining": skill_obj.duration,
-                                "remove_func": remove_func,
-                            })
-                        print(f"{target.name} の何かが強化された！")
-                    except Exception as e:
-                        print(f"スキル効果の適用中にエラー: {e}")
-                elif isinstance(skill_obj.effect, str):
-                    try:
-                        if skill_obj.effect == "speed_up":
-                            amount = 5
-                            target.speed += amount
-                            def revert(m=target, a=amount):
-                                m.speed -= a
-                        elif skill_obj.effect == "atk_def_up":
-                            amount = 5
-                            target.attack += amount
-                            target.defense += amount
-                            def revert(m=target, a=amount):
-                                m.attack -= a
-                                m.defense -= a
-                        else:
-                            print(f"{skill_obj.effect} の効果は未実装です。")
-                            continue
-                        if skill_obj.duration > 0:
-                            target.status_effects.append({
-                                "name": skill_obj.name,
-                                "remaining": skill_obj.duration,
-                                "remove_func": revert,
-                            })
-                        print(f"{target.name} の能力が上がった！")
-                    except Exception as e:
-                        print(f"スキル効果の適用中にエラー: {e}")
-
-        elif skill_obj.skill_type in ("debuff", "status"):
-            if isinstance(skill_obj.effect, str):
-                apply_status(target, skill_obj.effect, skill_obj.duration)
+        if callable(skill_obj.effect):
+            try:
+                remove_func = skill_obj.effect(target)
+                if skill_obj.duration > 0 and skill_obj.skill_type == "buff":
+                    target.status_effects.append({
+                        "name": skill_obj.name,
+                        "remaining": skill_obj.duration,
+                        "remove_func": remove_func,
+                    })
+                print(f"{target.name} の何かが強化された！")
+            except Exception as e:
+                print(f"スキル効果の適用中にエラー: {e}")
+        elif isinstance(skill_obj.effect, str):
+            effect_func = SKILL_EFFECT_MAP.get(skill_obj.effect)
+            if effect_func:
+                try:
+                    effect_func(caster, target, skill_obj)
+                except Exception as e:
+                    print(f"スキル効果の適用中にエラー: {e}")
             else:
-                print(f"{skill_obj.name} の効果は未実装です。")
-
+                print(f"{skill_obj.effect} の効果は未実装です。")
         else:
-            print(f"スキル「{skill_obj.name}」は効果がなかった...") # 未対応のスキルタイプなど
+            if skill_obj.skill_type not in ("attack", "heal"):
+                print(f"スキル「{skill_obj.name}」は効果がなかった...")
 
 def display_party_status(party: list[Monster], party_name: str):
     """パーティのステータスを表示します。"""

--- a/src/monster_rpg/skills/skill_actions.py
+++ b/src/monster_rpg/skills/skill_actions.py
@@ -1,0 +1,94 @@
+"""Common skill action utilities."""
+
+from __future__ import annotations
+from typing import Callable
+
+from ..monsters.monster_class import Monster
+
+
+def deal_damage(target: Monster, amount: int) -> None:
+    """Inflict raw damage to a monster and print result."""
+    target.hp -= amount
+    print(f"{target.name} に {amount} のダメージ！ (残りHP: {max(0, target.hp)})")
+    if target.hp <= 0:
+        target.is_alive = False
+        print(f"{target.name} は倒れた！")
+
+
+def simple_attack(caster: Monster, target: Monster, power: int) -> None:
+    """Basic attack damage ignoring caster stats."""
+    actual = max(1, power - target.defense)
+    deal_damage(target, actual)
+
+
+def simple_heal(target: Monster, amount: int) -> None:
+    before = target.hp
+    target.hp = min(target.max_hp, target.hp + amount)
+    healed = target.hp - before
+    print(f"{target.name} のHPが {healed} 回復した！ (現在HP: {target.hp})")
+
+
+def _buff_speed(caster: Monster, target: Monster, skill) -> None:
+    amount = 5
+    target.speed += amount
+
+    def revert(m=target, a=amount):
+        m.speed -= a
+
+    if skill.duration > 0:
+        target.status_effects.append(
+            {"name": skill.name, "remaining": skill.duration, "remove_func": revert}
+        )
+    print(f"{target.name} の能力が上がった！")
+
+
+def _buff_atk_def(caster: Monster, target: Monster, skill) -> None:
+    amount = 5
+    target.attack += amount
+    target.defense += amount
+
+    def revert(m=target, a=amount):
+        m.attack -= a
+        m.defense -= a
+
+    if skill.duration > 0:
+        target.status_effects.append(
+            {"name": skill.name, "remaining": skill.duration, "remove_func": revert}
+        )
+    print(f"{target.name} の能力が上がった！")
+
+
+def _apply_status(caster: Monster, target: Monster, skill) -> None:
+    from ..battle import apply_status
+
+    apply_status(target, skill.effect, skill.duration)
+
+
+def _revive(caster: Monster, target: Monster, skill) -> None:
+    if target.is_alive:
+        print(f"{target.name} はまだ倒れていない。")
+        return
+    target.is_alive = True
+    target.hp = target.max_hp // 2
+    print(f"{target.name} が復活した！ HPが半分回復した。")
+
+
+# Map of effect names to handler functions
+SKILL_EFFECT_MAP: dict[str, Callable[[Monster, Monster, object], None]] = {
+    "speed_up": _buff_speed,
+    "atk_def_up": _buff_atk_def,
+    "poison": _apply_status,
+    "burn": _apply_status,
+    "freeze": _apply_status,
+    "paralyze": _apply_status,
+    "regen": _apply_status,
+    "fear": _apply_status,
+    "blind": _apply_status,
+    "slow": _apply_status,
+    "silence": _apply_status,
+    "curse": _apply_status,
+    "stun": _apply_status,
+    "sleep": _apply_status,
+    "confuse": _apply_status,
+    "revive": _revive,
+}

--- a/tests/test_skill_actions.py
+++ b/tests/test_skill_actions.py
@@ -1,0 +1,22 @@
+import unittest
+
+from monster_rpg.battle import apply_skill_effect, process_status_effects
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.skills.skills import ALL_SKILLS
+from monster_rpg.skills.skill_actions import SKILL_EFFECT_MAP
+
+
+class SkillActionsTests(unittest.TestCase):
+    def test_speed_up_via_skill_actions(self):
+        self.assertIn('speed_up', SKILL_EFFECT_MAP)
+        m = Monster('Hero', hp=20, attack=5, defense=5, speed=10)
+        skill = ALL_SKILLS['speed_up']
+        apply_skill_effect(m, [m], skill, all_allies=[m])
+        self.assertEqual(m.speed, 15)
+        for _ in range(skill.duration):
+            process_status_effects(m)
+        self.assertEqual(m.speed, 10)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `skill_actions.py` with common damage/heal/buff helpers
- refactor `apply_skill_effect` to use `SKILL_EFFECT_MAP`
- add tests covering new skill action flow

## Testing
- `pip install -e .`
- `pip install Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b46fac10832189002fda54576341