### PR TITLE
Add enemy party generation

### DIFF
--- a/tests/test_create_enemy_party.py
+++ b/tests/test_create_enemy_party.py
@@ -1,0 +1,25 @@
+import random
+import unittest
+
+from monster_rpg.map_data import Location
+from monster_rpg.monsters import Monster
+
+class CreateEnemyPartyTests(unittest.TestCase):
+    def test_party_generation_deterministic(self):
+        loc = Location(
+            location_id="test",
+            name="test",
+            description="",
+            enemy_pool={"slime": 70, "goblin": 30},
+            party_size=[1, 2],
+            encounter_rate=1.0,
+        )
+        random.seed(0)
+        party = loc.create_enemy_party()
+        self.assertIsNotNone(party)
+        self.assertTrue(1 <= len(party) <= 2)
+        self.assertTrue(all(isinstance(m, Monster) for m in party))
+        self.assertEqual([m.monster_id for m in party], ["slime", "goblin"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `Location` to generate enemy parties
- support `enemy_pool` and `party_size` fields when loading locations
- add unit test for deterministic party generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b97775c483219e8e961f963fc536