### PR TITLE
Add enemy pool notes to README

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -47,7 +47,16 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
 - `skills/__init__.py` &mdash; an empty module used to mark the directory as a package.
 
 ### Maps
-- `map_data.py` &mdash; defines the `Location` class and the dictionary `LOCATIONS` which describes available areas and how they connect. `STARTING_LOCATION_ID` indicates where the player begins.
+- `map_data.py` &mdash; defines the `Location` class and the dictionary `LOCATIONS` which describes available areas and how they connect. `STARTING_LOCATION_ID` indicates where the player begins. Locations can include an `enemy_pool` dict for weighted encounters and a `party_size` range for the number of enemies.
+
+Example weighted enemy pool:
+
+```json
+{
+  "enemy_pool": { "slime": 70, "goblin": 30 },
+  "party_size": [1, 2]
+}
+```
 
 Other notable modules include `player.py` (player data and save/load logic), `battle.py` (battle system), and `monsters/synthesis_rules.py` (monster fusion recipes).
 

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -45,7 +45,16 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 - `skills/__init__.py` — ディレクトリをパッケージとして扱うための空モジュールです。
 
 ### マップ
-- `map_data.py` — `Location` クラスと、各エリアの接続関係を示す辞書 `LOCATIONS` を定義します。 `STARTING_LOCATION_ID` がプレイヤーの初期位置です。
+- `map_data.py` — `Location` クラスと、各エリアの接続関係を示す辞書 `LOCATIONS` を定義します。 `STARTING_LOCATION_ID` がプレイヤーの初期位置です。各場所では、出現モンスターとその重みを設定する `enemy_pool` と、敵の数範囲を指定する `party_size` を利用できます。
+
+例:
+
+```json
+{
+  "enemy_pool": { "slime": 70, "goblin": 30 },
+  "party_size": [1, 2]
+}
+```
 
 その他、`player.py` (プレイヤーデータとセーブ/ロード処理)、`battle.py` (戦闘システム)、`monsters/synthesis_rules.py` (モンスター合成レシピ) などのモジュールがあります。
 


### PR DESCRIPTION
## Summary
- document `enemy_pool` and `party_size` in the map section of both EN/JA readmes
- show an example weighted enemy pool json snippet

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c49f89648321abb41bf36a2be30f