### PR TITLE
Add skill learnset system for monsters

### DIFF
--- a/src/monster_rpg/monsters/monster_data.py
+++ b/src/monster_rpg/monsters/monster_data.py
@@ -823,3 +823,14 @@ ALL_MONSTERS = {
     "electro_mantis": ELECTRO_MANTIS,
 }
 
+# レベルアップ時に習得するスキル設定
+LEARNSETS = {
+    "slime": {2: ["guard_up"]},
+    "goblin": {3: ["power_up"]},
+    "wolf": {4: ["speed_up"]},
+}
+
+for mid, ls in LEARNSETS.items():
+    if mid in ALL_MONSTERS:
+        ALL_MONSTERS[mid].learnset = ls
+

--- a/tests/test_skill_learnset.py
+++ b/tests/test_skill_learnset.py
@@ -1,0 +1,15 @@
+import io
+from contextlib import redirect_stdout
+from monster_rpg.monsters.monster_data import SLIME
+
+
+def test_monster_learns_skill_at_level():
+    m = SLIME.copy()
+    exp_needed = m.calculate_exp_to_next_level()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        m.gain_exp(exp_needed)
+    output = buf.getvalue()
+    skill_names = [s.name for s in m.skills]
+    assert "ガードアップ を覚えた" in output
+    assert "ガードアップ" in skill_names


### PR DESCRIPTION
## Summary
- monsters can now have level-based learnsets
- monsters copy their learnsets when cloned
- learnset entries added for Slime, Goblin and Wolf
- new unit test verifies skill learning when leveling

## Testing
- `pip install -q Flask`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ca10d104832191b6ef9207cffc4c