### PR TITLE
Enable equipment stats in damage

### DIFF
--- a/src/monster_rpg/battle.py
+++ b/src/monster_rpg/battle.py
@@ -130,7 +130,7 @@ def apply_status(target: Monster, status_name: str, duration: int | None = None)
 
 def calculate_damage(attacker: Monster, defender: Monster) -> int:
     """通常攻撃のダメージを計算します。"""
-    base = attacker.attack - defender.defense
+    base = attacker.total_attack() - defender.total_defense()
     damage = max(1, base)
 
     multiplier = ELEMENTAL_MULTIPLIERS.get((attacker.element, defender.element))

--- a/tests/test_battle_damage.py
+++ b/tests/test_battle_damage.py
@@ -3,6 +3,7 @@ import unittest
 
 from monster_rpg.battle import calculate_damage
 from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.items.equipment import ALL_EQUIPMENT
 
 class DamageCalculationTests(unittest.TestCase):
     def test_elemental_multiplier(self):
@@ -18,6 +19,19 @@ class DamageCalculationTests(unittest.TestCase):
         random.seed(31)  # first random < 0.1
         dmg = calculate_damage(attacker, defender)
         self.assertEqual(dmg, 30)  # (20-5)=15 *1 *2 -> 30
+
+    def test_equipment_modifies_damage(self):
+        attacker = Monster('Hero', hp=30, attack=10, defense=3)
+        defender = Monster('Monster', hp=30, attack=10, defense=3)
+        random.seed(2)
+        base_dmg = calculate_damage(attacker, defender)
+
+        attacker.equip(ALL_EQUIPMENT['bronze_sword'])
+        defender.equip(ALL_EQUIPMENT['leather_armor'])
+        random.seed(2)
+        equipped_dmg = calculate_damage(attacker, defender)
+
+        self.assertGreater(equipped_dmg, base_dmg)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- factor equipped weapon/armor into damage calculations
- verify equipped items influence damage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d5a5a91883219f4905e90df7ebcb