### PR TITLE
Implement equipment title system

### DIFF
--- a/src/monster_rpg/items/__init__.py
+++ b/src/monster_rpg/items/__init__.py
@@ -1,2 +1,9 @@
 from .item_data import Item, ALL_ITEMS
-from .equipment import Equipment, ALL_EQUIPMENT, CRAFTING_RECIPES
+from .equipment import (
+    Equipment,
+    ALL_EQUIPMENT,
+    CRAFTING_RECIPES,
+    EquipmentInstance,
+    create_titled_equipment,
+)
+from .titles import Title, ALL_TITLES

--- a/src/monster_rpg/items/equipment.py
+++ b/src/monster_rpg/items/equipment.py
@@ -1,4 +1,10 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import uuid
+import random
+from typing import List
+
+from .titles import Title, ALL_TITLES
+from ..skills.skills import ALL_SKILLS
 
 @dataclass
 class Equipment:
@@ -16,6 +22,58 @@ ALL_EQUIPMENT = {
     BRONZE_SWORD.equip_id: BRONZE_SWORD,
     LEATHER_ARMOR.equip_id: LEATHER_ARMOR,
 }
+
+
+@dataclass
+class EquipmentInstance:
+    """Actual equipment with an optional Title attached."""
+    base_item: Equipment
+    title: Title | None
+    instance_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    @property
+    def name(self) -> str:
+        if self.title:
+            return f"{self.title.name} {self.base_item.name}"
+        return self.base_item.name
+
+    @property
+    def slot(self) -> str:
+        return self.base_item.slot
+
+    @property
+    def total_attack(self) -> int:
+        bonus = self.title.stat_bonuses.get("attack", 0) if self.title else 0
+        return self.base_item.attack + bonus
+
+    @property
+    def total_defense(self) -> int:
+        bonus = self.title.stat_bonuses.get("defense", 0) if self.title else 0
+        return self.base_item.defense + bonus
+
+    @property
+    def total_speed(self) -> int:
+        return self.title.stat_bonuses.get("speed", 0) if self.title else 0
+
+    @property
+    def granted_skills(self) -> List:
+        if not self.title:
+            return []
+        objs = []
+        for sid in self.title.added_skills:
+            if sid in ALL_SKILLS:
+                objs.append(ALL_SKILLS[sid])
+        return objs
+
+
+def create_titled_equipment(base_equip_id: str) -> EquipmentInstance | None:
+    """Create EquipmentInstance with random title."""
+    if base_equip_id not in ALL_EQUIPMENT:
+        return None
+    base_item = ALL_EQUIPMENT[base_equip_id]
+    possible_titles = list(ALL_TITLES.values())
+    chosen = random.choice(possible_titles)
+    return EquipmentInstance(base_item=base_item, title=chosen)
 
 # simple crafting recipes: item_id -> quantity
 CRAFTING_RECIPES = {

--- a/src/monster_rpg/items/titles.py
+++ b/src/monster_rpg/items/titles.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+@dataclass
+class Title:
+    """Prefix title applied to equipment."""
+    title_id: str
+    name: str
+    description: str
+    stat_bonuses: Dict[str, int] = field(default_factory=dict)
+    added_skills: List[str] = field(default_factory=list)
+
+TITLE_SHARP = Title(
+    title_id="sharp",
+    name="鋭い",
+    description="攻撃性能が高められている。",
+    stat_bonuses={"attack": 5},
+)
+
+TITLE_STURDY = Title(
+    title_id="sturdy",
+    name="頑丈な",
+    description="防御性能が高められている。",
+    stat_bonuses={"defense": 5},
+)
+
+TITLE_QUICK = Title(
+    title_id="quick",
+    name="俊足の",
+    description="素早さが少し上昇する。",
+    stat_bonuses={"speed": 3},
+)
+
+TITLE_MAGICAL = Title(
+    title_id="magical",
+    name="魔力を秘めた",
+    description="装備者に新たなスキルを授ける。",
+    added_skills=["fireball"],
+)
+
+ALL_TITLES = {
+    TITLE_SHARP.title_id: TITLE_SHARP,
+    TITLE_STURDY.title_id: TITLE_STURDY,
+    TITLE_QUICK.title_id: TITLE_QUICK,
+    TITLE_MAGICAL.title_id: TITLE_MAGICAL,
+}

--- a/src/monster_rpg/monsters/monster_class.py
+++ b/src/monster_rpg/monsters/monster_class.py
@@ -148,18 +148,43 @@ class Monster:
         print("-" * 20)
 
     def equip(self, equipment):
-        """Equip an Equipment object to this monster."""
+        """Equip an Equipment or EquipmentInstance to this monster."""
         if equipment is None:
             return
         self.equipment[equipment.slot] = equipment
 
     def total_attack(self):
-        bonus = sum(getattr(e, 'attack', 0) for e in self.equipment.values())
+        bonus = 0
+        for e in self.equipment.values():
+            if hasattr(e, 'total_attack'):
+                bonus += e.total_attack
+            else:
+                bonus += getattr(e, 'attack', 0)
         return self.attack + bonus
 
     def total_defense(self):
-        bonus = sum(getattr(e, 'defense', 0) for e in self.equipment.values())
+        bonus = 0
+        for e in self.equipment.values():
+            if hasattr(e, 'total_defense'):
+                bonus += e.total_defense
+            else:
+                bonus += getattr(e, 'defense', 0)
         return self.defense + bonus
+
+    def total_speed(self):
+        bonus = 0
+        for e in self.equipment.values():
+            if hasattr(e, 'total_speed'):
+                bonus += e.total_speed
+        return self.speed + bonus
+
+    @property
+    def total_skills(self):
+        skills = self.skills[:]
+        for e in self.equipment.values():
+            if hasattr(e, 'granted_skills'):
+                skills.extend(e.granted_skills)
+        return skills
 
     def _try_evolution(self):
         """Check evolution rules and evolve if conditions are met."""

--- a/src/monster_rpg/player.py
+++ b/src/monster_rpg/player.py
@@ -9,7 +9,12 @@ from .monsters.synthesis_rules import (
     SYNTHESIS_ITEMS_REQUIRED,
     MONSTER_ITEM_RECIPES,
 )
-from .items.equipment import ALL_EQUIPMENT, CRAFTING_RECIPES
+from .items.equipment import (
+    ALL_EQUIPMENT,
+    CRAFTING_RECIPES,
+    create_titled_equipment,
+    EquipmentInstance,
+)
 import random  # 将来的にスキル継承などで使うかも
 import copy
 from .monster_book import MonsterBook
@@ -369,16 +374,28 @@ class Player:
                 if getattr(self.items[i], "item_id", None) == item_id and removed < qty:
                     self.items.pop(i)
                     removed += 1
-        equip = ALL_EQUIPMENT[equip_id]
-        self.equipment_inventory.append(equip)
-        print(f"{equip.name} を作成した！")
-        return equip
+        new_equip = create_titled_equipment(equip_id)
+        if new_equip:
+            self.equipment_inventory.append(new_equip)
+            print(f"{new_equip.name} を作成した！")
+            return new_equip
+        print("装備の作成に失敗した。")
+        return None
 
     def equip_to_monster(self, party_idx, equip_id):
         if not (0 <= party_idx < len(self.party_monsters)):
             print("無効なモンスター番号")
             return False
-        equip = next((e for e in self.equipment_inventory if e.equip_id == equip_id), None)
+        equip = None
+        for e in self.equipment_inventory:
+            if isinstance(e, EquipmentInstance):
+                if e.instance_id == equip_id or e.base_item.equip_id == equip_id:
+                    equip = e
+                    break
+            else:
+                if getattr(e, "equip_id", None) == equip_id:
+                    equip = e
+                    break
         if not equip:
             print("その装備を所持していない。")
             return False


### PR DESCRIPTION
## Summary
- add `titles.py` defining equipment prefix titles
- extend equipment module with `EquipmentInstance` and `create_titled_equipment`
- update player crafting to produce titled equipment
- allow equipping of both base equipment and instances
- expose new classes in package `__init__`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d9932ff08321880b60ff924a7c23