### PR TITLE
Fix equipment skill copying

### DIFF
--- a/src/monster_rpg/items/equipment.py
+++ b/src/monster_rpg/items/equipment.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 import uuid
 import random
 from typing import List
+import copy
 
 from .titles import Title, ALL_TITLES
 from ..skills.skills import ALL_SKILLS
@@ -62,7 +63,7 @@ class EquipmentInstance:
         objs = []
         for sid in self.title.added_skills:
             if sid in ALL_SKILLS:
-                objs.append(ALL_SKILLS[sid])
+                objs.append(copy.deepcopy(ALL_SKILLS[sid]))
         return objs
 
 

--- a/tests/test_equipment_granted_skills.py
+++ b/tests/test_equipment_granted_skills.py
@@ -1,0 +1,20 @@
+import unittest
+
+from monster_rpg.items.equipment import EquipmentInstance, BRONZE_SWORD
+from monster_rpg.items.titles import TITLE_MAGICAL
+from monster_rpg.skills.skills import ALL_SKILLS
+
+
+class EquipmentGrantedSkillsTests(unittest.TestCase):
+    def test_granted_skills_are_deepcopied(self):
+        equip = EquipmentInstance(base_item=BRONZE_SWORD, title=TITLE_MAGICAL)
+        skills = equip.granted_skills
+        self.assertTrue(skills)
+        original_power = ALL_SKILLS['fireball'].power
+        skills[0].power += 10
+        self.assertEqual(ALL_SKILLS['fireball'].power, original_power)
+        self.assertIsNot(skills[0], ALL_SKILLS['fireball'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- deepcopy skills granted by equipment titles to avoid mutation
- test that modifying a granted skill does not alter the master skill list

## Testing
- `pip install -e .`
- `pip install Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e99c8c0c8321903b00e2b1dc31cf