### PR TITLE
Implement total_speed turn order

### DIFF
--- a/src/monster_rpg/battle.py
+++ b/src/monster_rpg/battle.py
@@ -282,7 +282,7 @@ def determine_turn_order(party_a: list[Monster], party_b: list[Monster]) -> list
     """Return the action order for this turn sorted by speed."""
     return sorted(
         [m for m in party_a + party_b if m.is_alive],
-        key=lambda m: m.speed,
+        key=lambda m: m.total_speed(),
         reverse=True,
     )
 

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -53,7 +53,7 @@ class Battle:
     def _prepare_turn(self):
         """Calculate turn order for the new turn."""
         alive = [m for m in self.player_party + self.enemy_party if m.is_alive]
-        self.turn_order = sorted(alive, key=lambda m: m.speed, reverse=True)
+        self.turn_order = sorted(alive, key=lambda m: m.total_speed(), reverse=True)
         self.current_index = 0
         self.log.append({"type": "info", "message": f"-- Turn {self.turn} --"})
 

--- a/tests/test_turn_order.py
+++ b/tests/test_turn_order.py
@@ -2,6 +2,8 @@ import unittest
 
 from monster_rpg.battle import determine_turn_order
 from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.items.equipment import EquipmentInstance, BRONZE_SWORD
+from monster_rpg.items.titles import TITLE_GALE
 
 class TurnOrderTests(unittest.TestCase):
     def test_determine_turn_order_by_speed(self):
@@ -10,6 +12,14 @@ class TurnOrderTests(unittest.TestCase):
         m3 = Monster('Mid', hp=10, attack=5, defense=3, speed=7)
         order = determine_turn_order([m1, m2], [m3])
         self.assertEqual([m.name for m in order], ['Fast', 'Mid', 'Slow'])
+
+    def test_title_speed_bonus_affects_turn_order(self):
+        boosted = Monster('Boosted', hp=10, attack=5, defense=3, speed=5)
+        normal = Monster('Normal', hp=10, attack=5, defense=3, speed=5)
+        equip = EquipmentInstance(base_item=BRONZE_SWORD, title=TITLE_GALE)
+        boosted.equip(equip)
+        order = determine_turn_order([boosted], [normal])
+        self.assertEqual(order[0], boosted)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- use monsters' `total_speed()` when sorting turn order
- respect total speed in web battle flow
- verify turn order respects speed-boosting titles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f2cddf688321af4b88082f783ffd