### PR TITLE
Update startup instructions

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -11,26 +11,26 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
 1. (Optional) Create and activate a virtual environment for Python 3.
 2. Initialize the SQLite database by running:
    ```bash
-   python database_setup.py
+   python -m monster_rpg.database_setup
    ```
    This creates `monster_rpg_save.db` if it does not already exist.
    A default user `player1` will be created automatically. Use `database_setup.create_user()` to add more users.
 3. (Optional) Run the classic CLI version:
    ```bash
-   python old_cli/main.py
+   python -m monster_rpg.old_cli.main
    ```
    This older interface will ask whether to load a save file or start a new game.
 4. To run the simple web server instead:
    ```bash
    pip install -r requirements.txt
-   python webapp.py
+   python -m monster_rpg.webapp
    ```
    `webapp.py` exposes only a couple JSON endpoints (like `/new_game` and
    `/load_game`) and does not include the battle system.
 5. Another web interface exists. Use the provided launcher script:
    ```bash
    pip install -r requirements.txt
-   python start_rpg.py
+   python -m monster_rpg.start_rpg
    ```
    This starts the server at <http://localhost:5000/> using Flask templates
    and provides the full game including battles.

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -11,25 +11,25 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 1. (任意) Python 3 用の仮想環境を作成して有効化します。
 2. 以下を実行してSQLiteデータベースを初期化します:
    ```bash
-   python database_setup.py
+   python -m monster_rpg.database_setup
    ```
    既に存在しない場合 `monster_rpg_save.db` が作成されます。
    デフォルトユーザー `player1` が自動で作成されます。追加ユーザーを作る場合は `database_setup.create_user()` を利用してください。
 3. (任意) 旧版のCLIを実行する場合:
    ```bash
-   python old_cli/main.py
+   python -m monster_rpg.old_cli.main
    ```
    セーブをロードするか新しく始めるか尋ねられます。
 4. 代わりに簡易ウェブサーバーを起動するには:
    ```bash
    pip install -r requirements.txt
-   python webapp.py
+   python -m monster_rpg.webapp
    ```
    `webapp.py` は `/new_game` や `/load_game` といった最低限のJSON APIのみを提供し、戦闘機能は含まれていません。
 5. `start_rpg.py` を使うと、完全なウェブ版を起動できます:
    ```bash
    pip install -r requirements.txt
-   python start_rpg.py
+   python -m monster_rpg.start_rpg
    ```
    これにより <http://localhost:5000/> でサーバーが起動し、Flaskテンプレートを使用した画面で戦闘を含む完全なゲームを楽しめます。
 


### PR DESCRIPTION
## Summary
- fix README instructions for running modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68480c1c84ec8321a52f8d0c824b80bd