### PR TITLE
Add exploration progress persistence

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -73,6 +73,9 @@ Other notable modules include `player.py` (player data and save/load logic), `ba
 
 ## Saving
 The game saves player data to `monster_rpg_save.db`. Only basic information is stored at the moment, but the structure is ready for expansion.
+If you upgrade the game, run `python -m monster_rpg.database_setup` again (or
+call `database_setup.initialize_database()` in code) to add any new tables such
+as the `exploration_progress` table to existing save files.
 
 ## Monster Images
 Place monster pictures under `src/monster_rpg/static/images/` on your local machine. The folder is kept in the repository via an empty `.gitkeep` file but ignored by Git so large image files do not get uploaded.

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -71,6 +71,7 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 
 ## セーブについて
 プレイヤーデータは `monster_rpg_save.db` に保存されます。現在は最低限の情報のみですが、拡張を見据えた構造になっています。
+ゲームをアップデートした際は `python -m monster_rpg.database_setup` を再実行するか、コード内で `database_setup.initialize_database()` を呼び出すことで、`exploration_progress` テーブルなどの新しいテーブルが既存のセーブに追加されます。
 
 ## モンスター画像
 モンスターの画像はローカルの `src/monster_rpg/static/images/` 以下に配置してください。リポジトリには空の `.gitkeep` ファイルのみ含め、大きな画像ファイルはGitにアップロードされないようにしています。

--- a/src/monster_rpg/database_setup.py
+++ b/src/monster_rpg/database_setup.py
@@ -81,6 +81,18 @@ def initialize_database():
     )
     """)
 
+    # exploration_progress テーブルの作成
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS exploration_progress (
+            player_id INTEGER,
+            location_id TEXT,
+            progress INTEGER,
+            PRIMARY KEY(player_id, location_id)
+        )
+        """
+    )
+
     _ensure_default_user(cursor)
 
     conn.commit()

--- a/src/monster_rpg/player.py
+++ b/src/monster_rpg/player.py
@@ -107,6 +107,17 @@ class Player:
                 (self.db_id, item_id),
             )
 
+        # 探索進捗を保存
+        cursor.execute(
+            "DELETE FROM exploration_progress WHERE player_id=?", (self.db_id,)
+        )
+        for loc_id, prog in self.exploration_progress.items():
+            cursor.execute(
+                "INSERT INTO exploration_progress (player_id, location_id, progress)"
+                " VALUES (?, ?, ?)",
+                (self.db_id, loc_id, prog),
+            )
+
         conn.commit()
         conn.close()
         print(f"{self.name} のデータがセーブされました。")
@@ -606,6 +617,14 @@ class Player:
             for (item_id,) in cursor.fetchall():
                 if item_id in ALL_ITEMS:
                     loaded_player.items.append(ALL_ITEMS[item_id])
+
+            # 探索進捗を読み込む
+            cursor.execute(
+                "SELECT location_id, progress FROM exploration_progress WHERE player_id=?",
+                (db_id,),
+            )
+            for loc_id, prog in cursor.fetchall():
+                loaded_player.exploration_progress[loc_id] = prog
 
             conn.close()
             print(f"{name} のデータがロードされました。")

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -52,5 +52,13 @@ class SaveLoadTests(unittest.TestCase):
         self.assertEqual(len(l2.party_monsters), 1)
         self.assertEqual(l2.party_monsters[0].monster_id, 'goblin')
 
+    def test_exploration_progress_saved_and_loaded(self):
+        player = Player('Explorer', user_id=self.user1)
+        player.increase_exploration('forest_entrance', 40)
+        player.save_game(self.db_path)
+
+        loaded = Player.load_game(self.db_path, user_id=self.user1)
+        self.assertEqual(loaded.get_exploration('forest_entrance'), 40)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create new `exploration_progress` table when initializing the DB
- save exploration progress and reload it when loading a game
- test persistence of exploration progress
- document that re-running `initialize_database()` will add new tables

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684815fd0cd48321ae6104a8af56438f