### PR TITLE
Fix mypy warnings and tweak battle code

### DIFF
--- a/src/monster_rpg/database_setup.py
+++ b/src/monster_rpg/database_setup.py
@@ -111,8 +111,10 @@ def create_user(username: str, password: str) -> int:
             (username, _hash_password(password)),
         )
         conn.commit()
-        user_id = cursor.lastrowid
-    return user_id
+        user_id_raw = cursor.lastrowid
+        if user_id_raw is None:
+            raise RuntimeError("Failed to retrieve user id")
+        return int(user_id_raw)
 
 
 def get_user_id(username: str, password: str | None = None) -> int | None:

--- a/src/monster_rpg/exploration.py
+++ b/src/monster_rpg/exploration.py
@@ -62,24 +62,24 @@ def generate_enemy_party(location: Location, player=None) -> list[Monster]:
         enemy_id = location.get_random_enemy_id()
         if not enemy_id:
             enemy_id = random.choice(location.possible_enemies)
-        enemy_instance = get_monster_instance_copy(enemy_id)
-        if enemy_instance:
+        enemy_copy = get_monster_instance_copy(enemy_id)
+        if enemy_copy:
             if player is not None and hasattr(player, "monster_book"):
-                player.monster_book.record_seen(enemy_instance.monster_id)
+                player.monster_book.record_seen(enemy_copy.monster_id)
             target_level = max(1, base_level + random.randint(-1, 1))
-            while enemy_instance.level < target_level:
-                enemy_instance.level_up()
-            enemy_party.append(enemy_instance)
+            while enemy_copy.level < target_level:
+                enemy_copy.level_up()
+            enemy_party.append(enemy_copy)
 
     if not enemy_party and location.possible_enemies:
         enemy_id = location.get_random_enemy_id() or random.choice(location.possible_enemies)
-        enemy_instance = get_monster_instance_copy(enemy_id)
-        if enemy_instance:
+        enemy_copy = get_monster_instance_copy(enemy_id)
+        if enemy_copy:
             if player is not None and hasattr(player, "monster_book"):
-                player.monster_book.record_seen(enemy_instance.monster_id)
+                player.monster_book.record_seen(enemy_copy.monster_id)
             target_level = max(1, base_level + random.randint(-1, 1))
-            while enemy_instance.level < target_level:
-                enemy_instance.level_up()
-            enemy_party.append(enemy_instance)
+            while enemy_copy.level < target_level:
+                enemy_copy.level_up()
+            enemy_party.append(enemy_copy)
 
     return enemy_party

--- a/src/monster_rpg/old_cli/main.py
+++ b/src/monster_rpg/old_cli/main.py
@@ -70,7 +70,8 @@ def game_loop(hero: Player): # 型ヒントを追加
             possible_moves = list(current_location_data.connections.items())
             
             for i, (direction_command, destination_id) in enumerate(possible_moves):
-                destination_name = LOCATIONS.get(destination_id).name if LOCATIONS.get(destination_id) else "不明な場所"
+                dest = LOCATIONS.get(destination_id)
+                destination_name = dest.name if dest else "不明な場所"
                 print(f"  {i + 1}: {direction_command} ({destination_name} へ)")
             print(f"  0: 移動をやめる")
 

--- a/src/monster_rpg/skills/skill_actions.py
+++ b/src/monster_rpg/skills/skill_actions.py
@@ -83,7 +83,7 @@ def _status_applier(name: str) -> Callable[[Monster, Monster, Skill], None]:
     return func
 
 
-SKILL_EFFECT_MAP: Dict[str, Callable[[Monster, Monster, Skill], None]] = {
+SKILL_EFFECT_MAP: Dict[str, Callable[..., None]] = {
     "speed_up": buff_speed_up,
     "atk_def_up": buff_atk_def_up,
     "revive": revive_target,


### PR DESCRIPTION
## Summary
- silence mypy errors in exploration and database setup
- update old CLI location lookup to avoid `None` attributes
- improve typing and helper functions in battle module
- relax skill action typing to allow kwargs

## Testing
- `pytest -q`
- `mypy src`
- `flake8 src/monster_rpg/battle.py`

------
https://chatgpt.com/codex/tasks/task_e_68481b31d9008321aae157064416eda1