### PR TITLE
Implement item effect utility

### DIFF
--- a/src/monster_rpg/items/__init__.py
+++ b/src/monster_rpg/items/__init__.py
@@ -7,6 +7,7 @@ from .equipment import (
     create_titled_equipment,
 )
 from .titles import Title, ALL_TITLES
+from .item_effects import apply_item_effect
 
 __all__ = [
     "Item",
@@ -18,4 +19,5 @@ __all__ = [
     "create_titled_equipment",
     "Title",
     "ALL_TITLES",
+    "apply_item_effect",
 ]

--- a/src/monster_rpg/items/item_effects.py
+++ b/src/monster_rpg/items/item_effects.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+from .item_data import Item
+
+if TYPE_CHECKING:
+    from ..monsters.monster_class import Monster
+
+
+def apply_item_effect(item: Item, target: Optional[Monster]) -> bool:
+    """Apply an item's effect to a target Monster.
+
+    Returns True if the effect was applied successfully.
+    """
+    if not getattr(item, "usable", False):
+        print(f"{item.name} はここでは使えない。")
+        return False
+
+    effect = getattr(item, "effect", {})
+    if not effect:
+        print("このアイテムはまだ効果が実装されていない。")
+        return False
+
+    etype = effect.get("type")
+
+    if etype == "heal_hp":
+        if target is None:
+            print("対象モンスターがいません。")
+            return False
+        if not target.is_alive:
+            print(f"{target.name} は倒れているため回復できない。")
+            return False
+        amount = effect.get("amount", 0)
+        before = target.hp
+        target.hp = min(target.max_hp, target.hp + amount)
+        healed = target.hp - before
+        print(f"{target.name} のHPが {healed} 回復した。")
+        return True
+
+    if etype == "heal_mp":
+        if target is None:
+            print("対象モンスターがいません。")
+            return False
+        amount = effect.get("amount", 0)
+        before = target.mp
+        target.mp = min(target.max_mp, target.mp + amount)
+        restored = target.mp - before
+        print(f"{target.name} のMPが {restored} 回復した。")
+        return True
+
+    if etype == "heal_full":
+        if target is None:
+            print("対象モンスターがいません。")
+            return False
+        if not target.is_alive:
+            print(f"{target.name} は倒れているため回復できない。")
+            return False
+        target.hp = target.max_hp
+        target.mp = target.max_mp
+        print(f"{target.name} のHPとMPが全回復した！")
+        return True
+
+    if etype == "revive":
+        if target is None:
+            print("対象モンスターがいません。")
+            return False
+        if target.is_alive:
+            print(f"{target.name} はまだ倒れていない。")
+            return False
+        target.is_alive = True
+        amount = effect.get("amount", "half")
+        if amount == "half":
+            target.hp = target.max_hp // 2
+        else:
+            try:
+                target.hp = min(target.max_hp, int(amount))
+            except (TypeError, ValueError):
+                target.hp = target.max_hp // 2
+        print(f"{target.name} が復活した！ HPが半分回復した。")
+        return True
+
+    if etype == "cure_status":
+        if target is None:
+            print("対象モンスターがいません。")
+            return False
+        status = effect.get("status")
+        before = len(target.status_effects)
+        target.status_effects = [e for e in target.status_effects if e["name"] != status]
+        if len(target.status_effects) < before:
+            print(f"{target.name} の {status} が治った。")
+            return True
+        print(f"{target.name} は {status} 状態ではない。")
+        return False
+
+    print("このアイテムはまだ効果が実装されていない。")
+    return False

--- a/src/monster_rpg/player.py
+++ b/src/monster_rpg/player.py
@@ -258,76 +258,12 @@ class Player:
             return False
 
         item = self.items[item_idx]
-        if not getattr(item, "usable", False):
-            print(f"{item.name} はここでは使えない。")
-            return False
+        from .items import apply_item_effect
 
-        effect = getattr(item, "effect", {})
-        if not effect:
-            print("このアイテムはまだ効果が実装されていない。")
-            return False
-
-        etype = effect.get("type")
-
-        if etype == "heal_hp":
-            if target_monster is None:
-                print("対象モンスターがいません。")
-                return False
-            if not target_monster.is_alive:
-                print(f"{target_monster.name} は倒れているため回復できない。")
-                return False
-            amount = effect.get("amount", 0)
-            before = target_monster.hp
-            target_monster.hp = min(target_monster.max_hp, target_monster.hp + amount)
-            healed = target_monster.hp - before
-            print(f"{target_monster.name} のHPが {healed} 回復した。")
+        success = apply_item_effect(item, target_monster)
+        if success:
             self.items.pop(item_idx)
-            return True
-
-        if etype == "heal_mp":
-            if target_monster is None:
-                print("対象モンスターがいません。")
-                return False
-            amount = effect.get("amount", 0)
-            before = target_monster.mp
-            target_monster.mp = min(target_monster.max_mp, target_monster.mp + amount)
-            restored = target_monster.mp - before
-            print(f"{target_monster.name} のMPが {restored} 回復した。")
-            self.items.pop(item_idx)
-            return True
-
-        if etype == "heal_full":
-            if target_monster is None:
-                print("対象モンスターがいません。")
-                return False
-            if not target_monster.is_alive:
-                print(f"{target_monster.name} は倒れているため回復できない。")
-                return False
-            target_monster.hp = target_monster.max_hp
-            target_monster.mp = target_monster.max_mp
-            print(f"{target_monster.name} のHPとMPが全回復した！")
-            self.items.pop(item_idx)
-            return True
-
-        if etype == "revive":
-            if target_monster is None:
-                print("対象モンスターがいません。")
-                return False
-            if target_monster.is_alive:
-                print(f"{target_monster.name} はまだ倒れていない。")
-                return False
-            target_monster.is_alive = True
-            amount = effect.get("amount", "half")
-            if amount == "half":
-                target_monster.hp = target_monster.max_hp // 2
-            else:
-                target_monster.hp = min(target_monster.max_hp, int(amount))
-            print(f"{target_monster.name} が復活した！ HPが半分回復した。")
-            self.items.pop(item_idx)
-            return True
-
-        print("このアイテムはまだ効果が実装されていない。")
-        return False
+        return success
 
     def rest_at_inn(self, cost):
         if self.gold >= cost:

--- a/tests/test_item_effects.py
+++ b/tests/test_item_effects.py
@@ -1,0 +1,43 @@
+import unittest
+
+from monster_rpg.items import ALL_ITEMS, apply_item_effect
+
+
+class DummyMonster:
+    def __init__(self, hp=30, mp=20):
+        self.name = "Dummy"
+        self.hp = hp
+        self.max_hp = hp
+        self.mp = mp
+        self.max_mp = mp
+        self.status_effects = []
+        self.is_alive = True
+
+
+class ItemEffectFunctionTests(unittest.TestCase):
+    def test_heal_hp_effect(self):
+        m = DummyMonster(hp=40)
+        m.hp = 10
+        result = apply_item_effect(ALL_ITEMS['small_potion'], m)
+        self.assertTrue(result)
+        self.assertEqual(m.hp, 40)
+
+    def test_revive_effect(self):
+        m = DummyMonster(hp=30)
+        m.hp = 0
+        m.is_alive = False
+        result = apply_item_effect(ALL_ITEMS['revive_scroll'], m)
+        self.assertTrue(result)
+        self.assertTrue(m.is_alive)
+        self.assertEqual(m.hp, m.max_hp // 2)
+
+    def test_cure_status_effect(self):
+        m = DummyMonster(hp=30)
+        m.status_effects.append({'name': 'poison', 'remaining': 2})
+        result = apply_item_effect(ALL_ITEMS['antidote'], m)
+        self.assertTrue(result)
+        self.assertFalse(any(e['name'] == 'poison' for e in m.status_effects))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- centralize item effect logic in `apply_item_effect`
- expose the new helper from the items package
- use the helper in `Player.use_item`
- test basic item effects

## Testing
- `pytest tests/test_item_effects.py -q`
- `pytest -q` *(fails: KeyError 'bronze_sword')*

------
https://chatgpt.com/codex/tasks/task_e_6848bc915ba0832191162192bbf306ed