### PR TITLE
Enable equipment drops and persistence

### DIFF
--- a/src/monster_rpg/battle.py
+++ b/src/monster_rpg/battle.py
@@ -3,6 +3,7 @@ import random
 from typing import cast
 from .player import Player  # Playerクラスは直接使わないが、型ヒントなどで参照される可能性を考慮
 from .monsters import Monster  # Monsterクラスのみ参照
+from .items.equipment import Equipment, EquipmentInstance
 from .skills.skills import Skill  # Skillクラスを参照
 from .skills.skill_actions import (
     SKILL_EFFECT_MAP,
@@ -384,7 +385,10 @@ def award_experience(alive_party: list[Monster], defeated_enemies: list[Monster]
         if player is not None:
             for item_obj, rate in getattr(enemy, "drop_items", []):
                 if random.random() < rate:
-                    player.items.append(item_obj)
+                    if isinstance(item_obj, (Equipment, EquipmentInstance)):
+                        player.equipment_inventory.append(item_obj)
+                    else:
+                        player.items.append(item_obj)
                     print(f"{item_obj.name} を手に入れた！")
 
     alive_monsters = [m for m in alive_party if m.is_alive]

--- a/src/monster_rpg/database_setup.py
+++ b/src/monster_rpg/database_setup.py
@@ -81,6 +81,15 @@ def initialize_database():
     )
     """)
 
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS player_equipment (
+        player_id INTEGER,
+        equip_id TEXT,
+        title_id TEXT,
+        instance_id TEXT
+    )
+    """)
+
     # exploration_progress テーブルの作成
     cursor.execute(
         """

--- a/src/monster_rpg/monsters/monster_data.py
+++ b/src/monster_rpg/monsters/monster_data.py
@@ -11,6 +11,7 @@ from .monster_class import (
 )
 from ..skills.skills import ALL_SKILLS
 from ..items.item_data import ALL_ITEMS
+from ..items.equipment import ALL_EQUIPMENT
 
 # モンスターランク定義
 RANK_S = "S"
@@ -55,7 +56,11 @@ GOBLIN = Monster(
     growth_type=GROWTH_TYPE_AVERAGE,
     monster_id="goblin",
     rank=RANK_D, # 例: ゴブリンはDランク
-    drop_items=[(ALL_ITEMS["small_potion"], 0.2), (ALL_ITEMS["magic_stone"], 0.1),(ALL_ITEMS["bronze_sword"],0.2),0]
+    drop_items=[
+        (ALL_ITEMS["small_potion"], 0.2),
+        (ALL_ITEMS["magic_stone"], 0.1),
+        (ALL_EQUIPMENT["bronze_sword"], 0.2),
+    ]
 )
 
 

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -20,6 +20,7 @@ import random
 import sqlite3
 from . import database_setup
 from .player import Player
+from .items.equipment import Equipment, EquipmentInstance
 from .monsters.monster_data import ALL_MONSTERS, MONSTER_BOOK_DATA
 from .items.item_data import ALL_ITEMS
 from .map_data import LOCATIONS, get_map_overview, get_map_grid, load_locations
@@ -678,7 +679,10 @@ def battle(user_id):
             for enemy in battle_obj.enemy_party:
                 for item_obj, rate in getattr(enemy, "drop_items", []):
                     if random.random() < rate:
-                        player.items.append(item_obj)
+                        if isinstance(item_obj, (Equipment, EquipmentInstance)):
+                            player.equipment_inventory.append(item_obj)
+                        else:
+                            player.items.append(item_obj)
                         msgs.append({"type": "info", "message": f"{item_obj.name} を手に入れた！"})
             msgs.append({"type": "info", "message": f"勝利した！ {gold_gain}G を得た。"})
         else:

--- a/tests/test_equipment_drop.py
+++ b/tests/test_equipment_drop.py
@@ -1,0 +1,23 @@
+import random
+import unittest
+
+from monster_rpg.battle import award_experience
+from monster_rpg.items.equipment import ALL_EQUIPMENT
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.player import Player
+
+class EquipmentDropTests(unittest.TestCase):
+    def test_drop_equipment_added_to_player_inventory(self):
+        enemy = Monster('Enemy', hp=30, attack=10, defense=5, level=1,
+                        drop_items=[(ALL_EQUIPMENT['bronze_sword'], 1.0)])
+        enemy.is_alive = False
+        ally = Monster('Ally', hp=30, attack=10, defense=5)
+        player = Player('Tester')
+        player.party_monsters.append(ally)
+        random.seed(0)
+        award_experience([ally], [enemy], player)
+        self.assertEqual(len(player.equipment_inventory), 1)
+        self.assertEqual(player.equipment_inventory[0].equip_id, 'bronze_sword')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -5,6 +5,7 @@ from monster_rpg import database_setup
 from monster_rpg.player import Player
 from monster_rpg.monsters.monster_data import ALL_MONSTERS
 from monster_rpg.items.item_data import ALL_ITEMS
+from monster_rpg.items.equipment import ALL_EQUIPMENT
 
 class SaveLoadTests(unittest.TestCase):
     def setUp(self):
@@ -59,6 +60,15 @@ class SaveLoadTests(unittest.TestCase):
 
         loaded = Player.load_game(self.db_path, user_id=self.user1)
         self.assertEqual(loaded.get_exploration('forest_entrance'), 40)
+
+    def test_save_and_load_equipment(self):
+        player = Player('EquipTester', user_id=self.user1)
+        player.equipment_inventory.append(ALL_EQUIPMENT['bronze_sword'])
+        player.save_game(self.db_path)
+
+        loaded = Player.load_game(self.db_path, user_id=self.user1)
+        self.assertEqual(len(loaded.equipment_inventory), 1)
+        self.assertEqual(loaded.equipment_inventory[0].equip_id, 'bronze_sword')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow monsters to drop equipment items
- distribute equipment to players correctly in battle functions
- save/load player equipment inventory via new `player_equipment` table
- update goblin drop table to use equipment
- add tests for equipment drops and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848be1c83e88321b0cf7bbea13bc60e