### PR TITLE
Add JSON loader for monsters

### DIFF
--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -41,6 +41,8 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 - `monsters/monster_data.py` — あらかじめ定義されたモンスターインスタンスと、ゲームで使用する辞書 `ALL_MONSTERS` を含みます。
 - `monsters/__init__.py` — モンスターのクラスやデータを簡単にインポートできるよう公開しています。
 
+`monsters/monsters.json` は JSON 形式のモンスター定義例です。`monster_loader.load_monsters()` を使うことで、ファイルからモンスターを一括読み込みできます。
+
 ### スキル
 - `skills/skills.py` — `Skill` クラスと複数の例示的なスキルを定義します。辞書 `ALL_SKILLS` に利用可能なスキルを格納しています。
 - `skills/__init__.py` — ディレクトリをパッケージとして扱うための空モジュールです。

--- a/src/monster_rpg/monsters/__init__.py
+++ b/src/monster_rpg/monsters/__init__.py
@@ -7,6 +7,7 @@ from .monster_class import (
     GROWTH_TYPE_LATE,
 )
 from .monster_data import ALL_MONSTERS
+from .monster_loader import load_monsters
 from .synthesis_rules import (
     SYNTHESIS_RECIPES,
     SYNTHESIS_ITEMS_REQUIRED,

--- a/src/monster_rpg/monsters/monster_loader.py
+++ b/src/monster_rpg/monsters/monster_loader.py
@@ -1,0 +1,76 @@
+import json
+import os
+from typing import Dict, Tuple
+
+from .monster_class import (
+    Monster,
+    GROWTH_TYPE_AVERAGE,
+    GROWTH_TYPE_EARLY,
+    GROWTH_TYPE_LATE,
+    RANK_S,
+    RANK_A,
+    RANK_B,
+    RANK_C,
+    RANK_D,
+)
+from ..skills.skills import ALL_SKILLS
+from ..items.item_data import ALL_ITEMS
+from ..items.equipment import ALL_EQUIPMENT
+from .monster_data import MonsterBookEntry
+
+
+def load_monsters(filepath: str | None = None) -> Tuple[Dict[str, Monster], Dict[str, MonsterBookEntry]]:
+    """Load monsters and monster book entries from a JSON file."""
+    if filepath is None:
+        filepath = os.path.join(os.path.dirname(__file__), "monsters.json")
+
+    with open(filepath, encoding="utf-8") as f:
+        text = f.read().replace("\u00a0", " ")
+        data = json.loads(text)
+
+    monsters: Dict[str, Monster] = {}
+    book_entries: Dict[str, MonsterBookEntry] = {}
+
+    for monster_id, attrs in data.items():
+        stats = attrs.get("stats", {})
+        m = Monster(
+            name=attrs.get("name", monster_id),
+            hp=stats.get("hp", 10),
+            attack=stats.get("attack", 5),
+            defense=stats.get("defense", 5),
+            mp=stats.get("mp", 30),
+            level=attrs.get("level", 1),
+            element=attrs.get("element"),
+            speed=stats.get("speed", 5),
+            ai_role=attrs.get("ai_role", "attacker"),
+            growth_type=attrs.get("growth_type", GROWTH_TYPE_AVERAGE),
+            monster_id=monster_id,
+            rank=attrs.get("rank", RANK_D),
+            image_filename=attrs.get("image_filename"),
+        )
+        # skills
+        skills = [ALL_SKILLS[s] for s in attrs.get("skills", []) if s in ALL_SKILLS]
+        m.skills = skills
+        # drop items
+        drops = []
+        for item_id, rate in attrs.get("drop_items", []):
+            item = ALL_ITEMS.get(item_id) or ALL_EQUIPMENT.get(item_id)
+            if item:
+                drops.append((item, rate))
+        m.drop_items = drops
+        # learnset
+        learnset = attrs.get("learnset", {})
+        m.learnset = {int(k): v for k, v in learnset.items()}
+
+        monsters[monster_id] = m
+
+        book = attrs.get("book", {})
+        book_entries[monster_id] = MonsterBookEntry(
+            monster_id=monster_id,
+            description=book.get("description", ""),
+            location_hint=book.get("location_hint", ""),
+            synthesis_hint=book.get("synthesis_hint", ""),
+            reward=book.get("reward", 0),
+        )
+
+    return monsters, book_entries

--- a/src/monster_rpg/monsters/monsters.json
+++ b/src/monster_rpg/monsters/monsters.json
@@ -1,0 +1,32 @@
+{
+  "slime": {
+    "name": "スライム",
+    "ai_role": "attacker",
+    "rank": "D",
+    "element": "水",
+    "image_filename": "slime.png",
+    "stats": {"hp": 25, "attack": 8, "defense": 5, "speed": 5, "mp": 30},
+    "skills": ["heal"],
+    "drop_items": [["small_potion", 0.5]],
+    "learnset": {"2": ["guard_up"]},
+    "book": {
+      "description": "ぷるぷるした弱小モンスター。水属性で、初心者の相手に最適。",
+      "location_hint": "村の近くの草原などに出現",
+      "synthesis_hint": "別種族と掛け合わせると特殊なモンスターが生まれるかも。"
+    }
+  },
+  "goblin": {
+    "name": "ゴブリン",
+    "ai_role": "attacker",
+    "rank": "D",
+    "element": "なし",
+    "stats": {"hp": 40, "attack": 12, "defense": 8, "speed": 7, "mp": 30},
+    "skills": ["fireball"],
+    "drop_items": [["small_potion", 0.2], ["magic_stone", 0.1], ["bronze_sword", 0.2]],
+    "book": {
+      "description": "粗暴な小型モンスター。集団で現れることが多い。",
+      "location_hint": "森や洞窟などの薄暗い場所に出没",
+      "synthesis_hint": "毒や闇のモンスターと掛け合わせると凶悪化するかも。"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a sample `monsters.json` file under the monsters package
- implement `monster_loader.load_monsters` to create `Monster` objects from JSON
- export `load_monsters` via `monsters.__init__`
- document JSON usage in `README_JA`

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849072b9dd88321ac92d1eea6867289