### PR TITLE
Improve load_monsters error handling

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -43,6 +43,8 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
 - `monsters/monster_data.py` &mdash; contains predefined monster instances and the dictionary `ALL_MONSTERS` used by the game.
 - `monsters/__init__.py` &mdash; exposes the monster classes and data for easier imports.
 
+Use `monster_loader.load_monsters()` to read monster definitions from `monsters/monsters.json`. A `ValueError` is raised if the file is missing or contains invalid JSON.
+
 ### Skills
 - `skills/skills.py` &mdash; defines the `Skill` class and several example skills. The dictionary `ALL_SKILLS` stores all available skills.
 - `skills/__init__.py` &mdash; an empty module used to mark the directory as a package.

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -41,7 +41,7 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 - `monsters/monster_data.py` — あらかじめ定義されたモンスターインスタンスと、ゲームで使用する辞書 `ALL_MONSTERS` を含みます。
 - `monsters/__init__.py` — モンスターのクラスやデータを簡単にインポートできるよう公開しています。
 
-`monsters/monsters.json` は JSON 形式のモンスター定義例です。`monster_loader.load_monsters()` を使うことで、ファイルからモンスターを一括読み込みできます。
+`monsters/monsters.json` は JSON 形式のモンスター定義例です。`monster_loader.load_monsters()` を使うことで、ファイルからモンスターを一括読み込みできます。ファイルが存在しない、または JSON が不正な場合は `ValueError` が送出されます。
 
 ### スキル
 - `skills/skills.py` — `Skill` クラスと複数の例示的なスキルを定義します。辞書 `ALL_SKILLS` に利用可能なスキルを格納しています。

--- a/src/monster_rpg/monsters/monster_loader.py
+++ b/src/monster_rpg/monsters/monster_loader.py
@@ -14,9 +14,16 @@ def load_monsters(filepath: str | None = None) -> Tuple[Dict[str, Monster], Dict
     if filepath is None:
         filepath = os.path.join(os.path.dirname(__file__), "monsters.json")
 
-    with open(filepath, encoding="utf-8") as f:
-        text = f.read().replace("\u00a0", " ")
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            text = f.read().replace("\u00a0", " ")
+    except FileNotFoundError as e:
+        raise ValueError(f"Monster data file not found: {filepath}") from e
+
+    try:
         data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid monster data JSON in {filepath}") from e
 
     monsters: Dict[str, Monster] = {}
     book_entries: Dict[str, MonsterBookEntry] = {}


### PR DESCRIPTION
## Summary
- handle file issues and JSON errors in `load_monsters`
- document the new `ValueError` behaviour in English and Japanese READMEs

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491616a0e08321825676797e5f5b4a