### PR TITLE
Clean up imports and validate monster data

### DIFF
--- a/src/monster_rpg/map_data.py
+++ b/src/monster_rpg/map_data.py
@@ -121,7 +121,6 @@ LOCATIONS: dict[str, Location] = {}
 
 def load_locations(filepath: str | None = None) -> None:
     """JSON ファイルから場所データを読み込み LOCATIONS を初期化する."""
-    global LOCATIONS
     if filepath is None:
         filepath = os.path.join(os.path.dirname(__file__), "map", "locations.json")
 

--- a/src/monster_rpg/monster_book.py
+++ b/src/monster_rpg/monster_book.py
@@ -1,5 +1,5 @@
 from typing import Set
-from .monsters.monster_data import MONSTER_BOOK_DATA, MonsterBookEntry
+from .monsters.monster_data import MONSTER_BOOK_DATA
 
 class MonsterBook:
     """プレイヤー毎に所持するモンスター図鑑。"""

--- a/tests/test_monster_data_consistency.py
+++ b/tests/test_monster_data_consistency.py
@@ -1,0 +1,16 @@
+import unittest
+
+from monster_rpg.monsters.monster_loader import load_monsters
+from monster_rpg.monsters.monster_data import ALL_MONSTERS
+
+
+class MonsterDataConsistencyTests(unittest.TestCase):
+    def test_json_and_python_monster_lists_match(self):
+        loaded, _ = load_monsters()
+        self.assertEqual(set(loaded.keys()), set(ALL_MONSTERS.keys()))
+        for mid, monster in loaded.items():
+            self.assertEqual(monster.name, ALL_MONSTERS[mid].name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove unused `MonsterBookEntry` import
- drop redundant `global LOCATIONS`
- add a test to ensure JSON and Python monster info match

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849266756848321b3c187a0befcd009