### PR TITLE
Add continue exploring button after battles

### DIFF
--- a/src/monster_rpg/templates/battle.html
+++ b/src/monster_rpg/templates/battle.html
@@ -6,6 +6,10 @@
   <li class="log-message-{{ m.type }}">{{ m.message }}</li>
 {% endfor %}
 </ul>
+<form action="{{ url_for('battle', user_id=user_id) }}" method="post">
+  <input type="hidden" name="continue_explore" value="1">
+  <button type="submit">Continue Exploring</button>
+</form>
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
 {% endblock %}
 

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -690,6 +690,8 @@ def battle(user_id):
         player.last_battle_log = msgs
         del active_battles[user_id]
         player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        if request.form.get("continue_explore"):
+            return redirect(url_for("explore", user_id=user_id))
         if request.method == 'POST':
             html = render_template('battle.html', messages=msgs, user_id=user_id)
             hp_vals = {


### PR DESCRIPTION
## Summary
- add a Continue Exploring form to battle result template
- redirect to explore when battle page receives `continue_explore`
- keep existing battle flow

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest tests/test_web_battle_json.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495e517f7483218909f1c65029484f