### PR TITLE
Add monster equipment support in web UI

### DIFF
--- a/src/monster_rpg/templates/party.html
+++ b/src/monster_rpg/templates/party.html
@@ -16,7 +16,9 @@
               "image": url_for("static", filename="images/" + m.image_filename) if m.image_filename else "",
               "stats": {"attack": m.attack, "defense": m.defense, "speed": m.speed},
               "skills": m.get_skill_details(),
-              "description": monster_book.get(m.monster_id).description if monster_book.get(m.monster_id) else "このモンスターに関する詳しい説明はまだ見つかっていない。"
+              "description": monster_book.get(m.monster_id).description if monster_book.get(m.monster_id) else "このモンスターに関する詳しい説明はまだ見つかっていない。",
+              "index": loop.index0,
+              "equipment": {slot: eq.name for slot, eq in m.equipment.items()}
             } | tojson | forceescape }}'>
           {% if m.image_filename %}
             <img class="monster-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
@@ -323,10 +325,14 @@
     const modal = document.getElementById('monster-detail-modal');
     const modalCardBody = document.getElementById('modal-card-body');
     const partyMembers = document.querySelectorAll('.party-member');
+    const equipmentList = {{ equipment_list|tojson|safe }};
+    const equipUrl = "{{ url_for('equip', user_id=user_id) }}";
+    let currentData = null;
 
     partyMembers.forEach(member => {
       member.addEventListener('click', () => {
         const monsterData = JSON.parse(member.dataset.details);
+        currentData = monsterData;
         displayMonsterDetails(monsterData);
       });
 
@@ -343,6 +349,19 @@
       }
 
       const expNeeded = data.exp_to_next - data.exp;
+      let equippedHtml = '';
+      const eqEntries = Object.entries(data.equipment || {});
+      if (eqEntries.length > 0) {
+        equippedHtml = '<ul>' + eqEntries.map(([s,n]) => `<li>${s}: ${n}</li>`).join('') + '</ul>';
+      } else {
+        equippedHtml = '<p>何も装備していない。</p>';
+      }
+      let equipListHtml = '';
+      if (equipmentList.length > 0) {
+        equipListHtml = '<ul>' + equipmentList.map(eq => `<li>${eq.name} <button class="equip-btn" data-equip-id="${eq.id}" data-idx="${data.index}">装備</button></li>`).join('') + '</ul>';
+      } else {
+        equipListHtml = '<p>装備を持っていない。</p>';
+      }
 
       modalCardBody.innerHTML = `
         <div class="card-image-area">
@@ -372,9 +391,35 @@
                 <h3>説明</h3>
                 <p>${data.description}</p>
             </div>
+            <div class="card-section card-equipment-list" style="margin-top: 16px;">
+                <h3>装備中</h3>
+                ${equippedHtml}
+                <h3>装備する</h3>
+                ${equipListHtml}
+            </div>
         </div>
       `;
       modal.classList.add('show');
+      modalCardBody.querySelectorAll('.equip-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const equipId = btn.dataset.equipId;
+          const idx = btn.dataset.idx;
+          fetch(equipUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ equip_id: equipId, monster_idx: idx })
+          })
+          .then(res => res.json())
+          .then(resp => {
+            if (resp.success) {
+              equipmentList.length = 0;
+              resp.equipment_inventory.forEach(e => equipmentList.push(e));
+              data.equipment = resp.monster_equipment;
+              displayMonsterDetails(data);
+            }
+          });
+        });
+      });
     }
 
     function closeModal() {

--- a/tests/test_equip_route.py
+++ b/tests/test_equip_route.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+
+from monster_rpg import database_setup
+from monster_rpg.web_main import app
+from monster_rpg.player import Player
+from monster_rpg.items.equipment import ALL_EQUIPMENT
+
+class EquipRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_equip.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.user_id = database_setup.create_user('tester', 'pw')
+        self.client = app.test_client()
+        player = Player('Tester', user_id=self.user_id)
+        player.add_monster_to_party('slime')
+        player.equipment_inventory.append(ALL_EQUIPMENT['bronze_sword'])
+        player.save_game(self.db_path, user_id=self.user_id)
+
+    def tearDown(self):
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_equip_to_monster(self):
+        resp = self.client.post(f'/equip/{self.user_id}', json={'equip_id': 'bronze_sword', 'monster_idx': 0})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data['success'])
+        loaded = Player.load_game(self.db_path, user_id=self.user_id)
+        self.assertEqual(len(loaded.equipment_inventory), 0)
+        self.assertIn('weapon', data['monster_equipment'])
+        self.assertEqual(data['monster_equipment']['weapon'], ALL_EQUIPMENT['bronze_sword'].name)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `/equip/<int:user_id>` route to equip inventory gear onto a monster
- extend party page to send equip requests and show equipment list
- add unit test for new route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a5a0d592c8321912a267308ea10f8