### PR TITLE
Add equipment slots and modal UI

### DIFF
--- a/src/monster_rpg/monsters/monster_class.py
+++ b/src/monster_rpg/monsters/monster_class.py
@@ -117,8 +117,9 @@ class Monster:
         self.drop_items = drop_items if drop_items else []
         self.scout_rate = scout_rate  # スカウト成功率(0.0-1.0)
         self.ai_role = ai_role
-        # 装備品スロット (weapon, armor など)
+        # 装備品スロット (weapon, armor など)。UI 表示のためスロットの一覧も保持
         self.equipment = {}
+        self.equipment_slots = ["weapon", "armor", "accessory"]
         self.learnset = learnset if learnset else {}
 
     def show_status(self):

--- a/src/monster_rpg/player.py
+++ b/src/monster_rpg/player.py
@@ -345,10 +345,27 @@ class Player:
         print("装備の作成に失敗した。")
         return None
 
-    def equip_to_monster(self, party_idx, equip_id):
+    def equip_to_monster(self, party_idx, equip_id=None, slot=None):
+        """Equip or unequip an item for the given monster.
+
+        If ``equip_id`` is ``None``, the method will unequip the item in
+        ``slot`` and return it to the player's inventory.
+        """
         if not (0 <= party_idx < len(self.party_monsters)):
             print("無効なモンスター番号")
             return False
+
+        monster = self.party_monsters[party_idx]
+
+        if equip_id is None:
+            if slot is None or slot not in monster.equipment:
+                print("そのスロットには装備がない。")
+                return False
+            equip = monster.equipment.pop(slot)
+            self.equipment_inventory.append(equip)
+            print(f"{monster.name} の {slot} を外した。")
+            return True
+
         equip = None
         for e in self.equipment_inventory:
             if isinstance(e, EquipmentInstance):
@@ -362,7 +379,7 @@ class Player:
         if not equip:
             print("その装備を所持していない。")
             return False
-        monster = self.party_monsters[party_idx]
+
         monster.equip(equip)
         self.equipment_inventory.remove(equip)
         print(f"{monster.name} に {equip.name} を装備した。")

--- a/src/monster_rpg/templates/party.html
+++ b/src/monster_rpg/templates/party.html
@@ -18,7 +18,8 @@
               "skills": m.get_skill_details(),
               "description": monster_book.get(m.monster_id).description if monster_book.get(m.monster_id) else "このモンスターに関する詳しい説明はまだ見つかっていない。",
               "index": loop.index0,
-              "equipment": {slot: eq.name for slot, eq in m.equipment.items()}
+              "equipment": {slot: eq.name for slot, eq in m.equipment.items()},
+              "equipment_slots": m.equipment_slots
             } | tojson | forceescape }}'>
           {% if m.image_filename %}
             <img class="monster-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
@@ -349,13 +350,14 @@
       }
 
       const expNeeded = data.exp_to_next - data.exp;
-      let equippedHtml = '';
-      const eqEntries = Object.entries(data.equipment || {});
-      if (eqEntries.length > 0) {
-        equippedHtml = '<ul>' + eqEntries.map(([s,n]) => `<li>${s}: ${n}</li>`).join('') + '</ul>';
-      } else {
-        equippedHtml = '<p>何も装備していない。</p>';
-      }
+      let equippedHtml = '<ul>';
+      (data.equipment_slots || []).forEach(slot => {
+        const name = data.equipment && data.equipment[slot] ? data.equipment[slot] : '空き';
+        const btn = data.equipment && data.equipment[slot] ? ` <button class="unequip-btn" data-slot="${slot}" data-idx="${data.index}">外す</button>` : '';
+        equippedHtml += `<li>${slot}: ${name}${btn}</li>`;
+      });
+      equippedHtml += '</ul>';
+
       let equipListHtml = '';
       if (equipmentList.length > 0) {
         equipListHtml = '<ul>' + equipmentList.map(eq => `<li>${eq.name} <button class="equip-btn" data-equip-id="${eq.id}" data-idx="${data.index}">装備</button></li>`).join('') + '</ul>';
@@ -408,6 +410,26 @@
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ equip_id: equipId, monster_idx: idx })
+          })
+          .then(res => res.json())
+          .then(resp => {
+            if (resp.success) {
+              equipmentList.length = 0;
+              resp.equipment_inventory.forEach(e => equipmentList.push(e));
+              data.equipment = resp.monster_equipment;
+              displayMonsterDetails(data);
+            }
+          });
+        });
+      });
+      modalCardBody.querySelectorAll('.unequip-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const idx = btn.dataset.idx;
+          const slot = btn.dataset.slot;
+          fetch(equipUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ equip_id: null, monster_idx: idx, slot: slot })
           })
           .then(res => res.json())
           .then(resp => {

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -377,19 +377,21 @@ def equip(user_id):
         data = request.get_json(silent=True) or {}
         equip_id = data.get('equip_id')
         idx = data.get('monster_idx')
+        slot = data.get('slot')
     else:
         equip_id = request.form.get('equip_id')
         idx = request.form.get('monster_idx')
+        slot = request.form.get('slot')
 
     try:
         idx_int = int(idx)
     except (TypeError, ValueError):
         return jsonify({'success': False, 'error': 'invalid index'}), 400
 
-    if not equip_id:
+    if equip_id in [None, ''] and slot is None:
         return jsonify({'success': False, 'error': 'invalid equip_id'}), 400
 
-    success = player.equip_to_monster(idx_int, equip_id)
+    success = player.equip_to_monster(idx_int, equip_id if equip_id not in ['', None] else None, slot)
     if success:
         player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
 


### PR DESCRIPTION
## Summary
- add default equipment slots to Monster
- extend equip handling to support unequipping
- expose slot parameter in `/equip` route
- serialize slot list and show slot-specific equip/unequip UI in party screen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a2e306c148321ad367630b6aca931