### PR TITLE
Implement active player unit highlighting

### DIFF
--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -374,6 +374,7 @@ function setupBattleUI() {
 
 function applyBattleData(data) {
     const allyUnits = document.querySelectorAll('.ally-party-display .battle-unit');
+    allyUnits.forEach(el => el.classList.remove('active-turn'));
     data.hp_values.player.forEach((info, idx) => {
         const unit = allyUnits[idx];
         if (!unit) return;
@@ -465,6 +466,12 @@ function applyBattleData(data) {
 
             updateTargets();
         }
+
+        const activeUnit = Array.from(allyUnits).find(u => {
+            const nameEl = u.querySelector('.member-name');
+            return nameEl && nameEl.textContent.trim() === data.current_actor.name;
+        });
+        if (activeUnit) activeUnit.classList.add('active-turn');
     }
 }
 


### PR DESCRIPTION
## Summary
- highlight the current player's monster in the battle UI
- remove any previous active highlight when applying new data

## Testing
- `pip install -e .`
- `pip install Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a68d2dc5883218822e4300250c759