### PR TITLE
Improve battle UI robustness

### DIFF
--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -188,7 +188,7 @@ button:hover { background: #004cd1; }
             {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
             
             <div class="battle-unit enemy{% if not e.is_alive %} down{% endif %}"
-                 data-down="{{ not e.is_alive }}"
+                 data-down="{{ not e.is_alive }}" data-unit-id="enemy-{{ loop.index0 }}"
                  data-name="{{ e.name }}" data-level="{{ e.level }}" data-hp="{{ e.hp }}"
                  data-max-hp="{{ e.max_hp }}" data-mp="{{ e.mp }}" data-max-mp="{{ e.max_mp }}"
                  data-attack="{{ e.attack }}" data-defense="{{ e.defense }}" data-speed="{{ e.speed }}">
@@ -214,8 +214,8 @@ button:hover { background: #004cd1; }
                 {% set hp_cls = 'hp-fill' %}
                 {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
 
-                <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m.id == current_actor.id %} active-turn{% endif %}"
-                     data-down="{{ not m.is_alive }}">
+                <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m is current_actor %} active-turn{% endif %}"
+                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}">
                     
                     {% if m.image_filename %}
                         <img class="unit-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
@@ -374,6 +374,8 @@ function setupBattleUI() {
             evt.preventDefault();
             const formData = new FormData(form);
             const postUrl = "{{ url_for('battle', user_id=user_id) }}";
+            const submitBtn = form.querySelector('button[type="submit"]');
+            if (submitBtn) submitBtn.disabled = true;
             fetch(postUrl, { method: 'POST', body: formData })
                 .then(resp => resp.json())
                 .then(data => {
@@ -384,12 +386,21 @@ function setupBattleUI() {
                         return;
                     }
                     applyBattleData(data);
+                })
+                .catch(err => {
+                    console.error('Fetch error', err);
+                    alert('通信エラーが発生しました');
+                })
+                .finally(() => {
+                    if (submitBtn) submitBtn.disabled = false;
                 });
         });
     }
 }
 
 function applyBattleData(data) {
+    const detailPanel = document.getElementById('enemy-detail');
+    if (detailPanel) detailPanel.classList.remove('open');
     const allyUnits = document.querySelectorAll('.ally-party-display .battle-unit');
     allyUnits.forEach(el => el.classList.remove('active-turn'));
     data.hp_values.player.forEach((info, idx) => {
@@ -484,10 +495,7 @@ function applyBattleData(data) {
             updateTargets();
         }
 
-        const activeUnit = Array.from(allyUnits).find(u => {
-            const nameEl = u.querySelector('.member-name');
-            return nameEl && nameEl.textContent.trim() === data.current_actor.name;
-        });
+        const activeUnit = Array.from(allyUnits).find(u => u.dataset.unitId === data.current_actor.unit_id);
         if (activeUnit) activeUnit.classList.add('active-turn');
     }
 }

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -761,8 +761,10 @@ def battle(user_id):
         actor = battle_obj.current_actor()
         actor_data = None
         if actor and actor in battle_obj.player_party:
+            idx = battle_obj.player_party.index(actor)
             actor_data = {
                 'name': actor.name,
+                'unit_id': f'ally-{idx}',
                 'skills': [
                     {
                         'name': sk.name,


### PR DESCRIPTION
## Summary
- add data-unit-id to monsters for stable DOM lookups
- disable submit button during async requests and handle fetch errors
- close enemy detail panel when refreshing battle data
- expose unit_id in battle JSON for accurate actor highlighting

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a649390fc8321aa99149b213cc271