### PR TITLE
Fix continue explore redirect

### DIFF
--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -737,6 +737,8 @@ def battle(user_id):
 
     if not battle_obj:
         if request.method == 'POST':
+            if request.form.get("continue_explore"):
+                return redirect(url_for('explore', user_id=user_id), code=307)
             return redirect(url_for('battle', user_id=user_id))
         loc = LOCATIONS.get(player.current_location_id)
         if not loc:

--- a/tests/test_continue_explore_redirect.py
+++ b/tests/test_continue_explore_redirect.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+
+from monster_rpg import database_setup
+from monster_rpg.web_main import app
+from monster_rpg.player import Player
+
+class ContinueExploreRedirectTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_continue.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.user_id = database_setup.create_user('tester', 'pw')
+        self.client = app.test_client()
+        player = Player('Tester', user_id=self.user_id)
+        player.save_game(self.db_path, user_id=self.user_id)
+
+    def tearDown(self):
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_continue_explore_redirect(self):
+        resp = self.client.post(f'/battle/{self.user_id}', data={'continue_explore': '1'})
+        self.assertEqual(resp.status_code, 307)
+        self.assertTrue(resp.headers['Location'].endswith(f'/explore/{self.user_id}'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- redirect continue_explore POSTs straight to the explore route
- add regression test for the redirect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab96a1e5483219a3ee5090f26db00