### PR TITLE
Implement damage popup on HP changes

### DIFF
--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -342,6 +342,15 @@ function setupBattleUI() {
     }
     window.updateTargets = updateTargets;
 
+    /* 現在のHPをdata属性に保存 */
+    document.querySelectorAll('.battle-unit').forEach(unit => {
+        const hpText = unit.querySelector('.hp-text');
+        if (hpText) {
+            const hp = parseInt(hpText.textContent.split('/')[0]);
+            if (!isNaN(hp)) unit.dataset.hp = hp;
+        }
+    });
+
     /* 敵詳細パネルの表示 */
     const detailPanel = document.getElementById('enemy-detail');
     const closeBtn = detailPanel.querySelector('.close-btn');
@@ -402,6 +411,8 @@ function updateUnitList(units, infoList) {
     infoList.forEach((info, idx) => {
         const unit = units[idx];
         if (!unit) return;
+        const prevHp = parseInt(unit.dataset.hp || '0');
+        unit.dataset.hp = info.hp;
         if (!info.alive) unit.classList.add('down');
         const fill = unit.querySelector('.hp-fill');
         const pct = Math.round(info.hp / info.max_hp * 100);
@@ -416,6 +427,10 @@ function updateUnitList(units, infoList) {
         }
         const text = unit.querySelector('.hp-text');
         if (text) text.textContent = info.hp + '/' + info.max_hp;
+
+        if (!isNaN(prevHp) && info.hp < prevHp) {
+            showDamageIndicator(unit, '-' + (prevHp - info.hp));
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- keep each unit's HP in a data attribute
- display popup damage indicators when units lose HP

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b86354b048321b7c4c58de34a6977