### PR TITLE
Enhance battle turn UI with MP bar

### DIFF
--- a/src/monster_rpg/static/battle_turn/battle_turn.css
+++ b/src/monster_rpg/static/battle_turn/battle_turn.css
@@ -101,6 +101,24 @@ body {
     font-size: 0.9rem;
     font-weight: bold;
 }
+.mp-bar {
+    width: 100%;
+    height: 10px;
+    background: #223;
+    border: 1px solid #112;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 4px;
+}
+.mp-fill {
+    height: 100%;
+    background: #0088ff;
+    box-shadow: inset 0 0 2px rgba(255, 255, 255, 0.4);
+}
+.mp-text {
+    font-size: 0.9rem;
+    font-weight: bold;
+}
 /* クリック可能な敵ユニットにカーソルを表示 */
 .enemy.battle-unit {
     cursor: pointer;

--- a/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -9,6 +9,16 @@ function setupBattleUI() {
         });
     });
 
+    /* MPバーのアニメーション */
+    document.querySelectorAll('.mp-fill').forEach(fill => {
+        const finalWidth = fill.style.width;
+        fill.style.width = '0%';
+        requestAnimationFrame(() => {
+            fill.style.transition = 'width 1s cubic-bezier(0.25, 1, 0.5, 1)';
+            fill.style.width = finalWidth;
+        });
+    });
+
     /* HP低下時の点滅 */
     document.querySelectorAll('.hp-fill.critical').forEach(el => el.classList.add('blink'));
 
@@ -120,6 +130,7 @@ function updateUnitList(units, infoList) {
         if (!unit) return;
         const prevHp = parseInt(unit.dataset.hp || '0');
         unit.dataset.hp = info.hp;
+        unit.dataset.mp = info.mp;
         if (!info.alive) unit.classList.add('down');
         const fill = unit.querySelector('.hp-fill');
         const pct = Math.round(info.hp / info.max_hp * 100);
@@ -134,6 +145,14 @@ function updateUnitList(units, infoList) {
         }
         const text = unit.querySelector('.hp-text');
         if (text) text.textContent = info.hp + '/' + info.max_hp;
+
+        const mpFill = unit.querySelector('.mp-fill');
+        const mpPct = Math.round(info.mp / info.max_mp * 100);
+        if (mpFill) {
+            mpFill.style.width = mpPct + '%';
+        }
+        const mpText = unit.querySelector('.mp-text');
+        if (mpText) mpText.textContent = info.mp + '/' + info.max_mp;
 
         if (!isNaN(prevHp) && info.hp < prevHp) {
             showDamageIndicator(unit, '-' + (prevHp - info.hp));
@@ -183,7 +202,9 @@ function applyBattleData(data) {
                 opt.value = 'skill' + idx;
                 opt.dataset.target = sk.target;
                 opt.dataset.scope = sk.scope;
-                opt.textContent = sk.name;
+                opt.dataset.cost = sk.cost;
+                opt.textContent = sk.name + (sk.cost ? ` (MP${sk.cost})` : '');
+                if (sk.cost > data.current_actor.mp) opt.disabled = true;
                 actionSel.appendChild(opt);
             });
 

--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -4,7 +4,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DotGothic16&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="{{ url_for('static', filename='battle_turn.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='battle_turn/battle_turn.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -27,8 +27,11 @@
                 <div class="member-info">
                     <div class="member-name">{{ e.name }}</div>
                     <div class="hp-bar"><div class="{{ hp_cls }}" style="width:{{ hp_pct }}%"></div></div>
+                    {% set mp_pct = (e.mp / e.max_mp * 100)|round(0) %}
+                    <div class="mp-bar"><div class="mp-fill" style="width:{{ mp_pct }}%"></div></div>
                 </div>
                 <div class="hp-text">{{ e.hp }}/{{ e.max_hp }}</div>
+                <div class="mp-text">{{ e.mp }}/{{ e.max_mp }}</div>
             </div>
         {% endfor %}
     </div>
@@ -43,7 +46,8 @@
                 {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
 
                 <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m is sameas current_actor %} active-turn{% endif %}"
-                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}">
+                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}"
+                     data-mp="{{ m.mp }}" data-max-mp="{{ m.max_mp }}">
                     
                     {% if m.image_filename %}
                         <img class="unit-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
@@ -51,8 +55,11 @@
                     <div class="member-info">
                         <div class="member-name">{{ m.name }}</div>
                         <div class="hp-bar"><div class="{{ hp_cls }}" style="width:{{ hp_pct }}%"></div></div>
+                        {% set mp_pct = (m.mp / m.max_mp * 100)|round(0) %}
+                        <div class="mp-bar"><div class="mp-fill" style="width:{{ mp_pct }}%"></div></div>
                     </div>
                     <div class="hp-text">{{ m.hp }}/{{ m.max_hp }}</div>
+                    <div class="mp-text">{{ m.mp }}/{{ m.max_mp }}</div>
                 </div>
             {% endfor %}
         </div>
@@ -118,5 +125,5 @@
 
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='battle_turn.js') }}"></script>
+<script src="{{ url_for('static', filename='battle_turn/battle_turn.js') }}"></script>
 {% endblock %}

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -836,8 +836,8 @@ def battle(user_id):
         if request.method == 'POST':
             html = render_template('battle.html', messages=msgs, user_id=user_id)
             hp_vals = {
-                'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.player_party],
-                'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+                'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.player_party],
+                'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
             }
             return jsonify({'hp_values': hp_vals, 'log': battle_obj.log, 'finished': True, 'turn': battle_obj.turn, 'html': html})
         return render_template('battle.html', messages=msgs, user_id=user_id)
@@ -845,8 +845,8 @@ def battle(user_id):
     current_actor = battle_obj.current_actor()
     if request.method == 'POST':
         hp_vals = {
-            'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.player_party],
-            'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+            'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.player_party],
+            'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
         }
         actor = battle_obj.current_actor()
         actor_data = None
@@ -855,11 +855,13 @@ def battle(user_id):
             actor_data = {
                 'name': actor.name,
                 'unit_id': f'ally-{idx}',
+                'mp': actor.mp,
                 'skills': [
                     {
                         'name': sk.name,
                         'target': getattr(sk, 'target', 'enemy'),
                         'scope': getattr(sk, 'scope', 'single'),
+                        'cost': getattr(sk, 'cost', 0),
                     }
                     for sk in actor.skills
                 ],


### PR DESCRIPTION
## Summary
- add MP bars below each unit's HP bar
- include current MP data in battle turn JSON
- display skill MP costs and disable options when insufficient

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ba4af16e483219dfadf27b20cb50b