### PR TITLE
Add MP bars to battle UI

### DIFF
--- a/src/monster_rpg/static/battle_turn/battle_turn.css
+++ b/src/monster_rpg/static/battle_turn/battle_turn.css
@@ -90,6 +90,15 @@ body {
     overflow: hidden;
     margin-bottom: 4px;
 }
+.mp-bar {
+    width: 100%;
+    height: 10px;
+    background: #222b44;
+    border: 1px solid #111;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 4px;
+}
 .hp-fill {
     height: 100%;
     background: #00e075;
@@ -97,9 +106,19 @@ body {
 }
 .hp-fill.low { background: #ffb100; }
 .hp-fill.critical { background: #ff3c3c; }
+.mp-fill {
+    height: 100%;
+    background: #0090ff;
+    box-shadow: inset 0 0 2px rgba(255, 255, 255, 0.4);
+}
 .hp-text {
     font-size: 0.9rem;
     font-weight: bold;
+}
+.mp-text {
+    font-size: 0.85rem;
+    font-weight: bold;
+    color: #9cd3ff;
 }
 /* クリック可能な敵ユニットにカーソルを表示 */
 .enemy.battle-unit {

--- a/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -49,12 +49,17 @@ function setupBattleUI() {
     }
     window.updateTargets = updateTargets;
 
-    /* 現在のHPをdata属性に保存 */
+    /* 現在のHP/MPをdata属性に保存 */
     document.querySelectorAll('.battle-unit').forEach(unit => {
         const hpText = unit.querySelector('.hp-text');
         if (hpText) {
             const hp = parseInt(hpText.textContent.split('/')[0]);
             if (!isNaN(hp)) unit.dataset.hp = hp;
+        }
+        const mpText = unit.querySelector('.mp-text');
+        if (mpText) {
+            const mp = parseInt(mpText.textContent.split('/')[0]);
+            if (!isNaN(mp)) unit.dataset.mp = mp;
         }
     });
 
@@ -120,6 +125,7 @@ function updateUnitList(units, infoList) {
         if (!unit) return;
         const prevHp = parseInt(unit.dataset.hp || '0');
         unit.dataset.hp = info.hp;
+        unit.dataset.mp = info.mp;
         if (!info.alive) unit.classList.add('down');
         const fill = unit.querySelector('.hp-fill');
         const pct = Math.round(info.hp / info.max_hp * 100);
@@ -134,6 +140,14 @@ function updateUnitList(units, infoList) {
         }
         const text = unit.querySelector('.hp-text');
         if (text) text.textContent = info.hp + '/' + info.max_hp;
+
+        const mpFill = unit.querySelector('.mp-fill');
+        const mpPct = Math.round(info.mp / info.max_mp * 100);
+        if (mpFill) {
+            mpFill.style.width = mpPct + '%';
+        }
+        const mpText = unit.querySelector('.mp-text');
+        if (mpText) mpText.textContent = info.mp + '/' + info.max_mp;
 
         if (!isNaN(prevHp) && info.hp < prevHp) {
             showDamageIndicator(unit, '-' + (prevHp - info.hp));

--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -13,6 +13,7 @@
         {% for e in enemy_party %}
             {% set hp_pct = (e.hp / e.max_hp * 100)|round(0) %}
             {% set hp_cls = 'hp-fill' %}
+            {% set mp_pct = (e.mp / e.max_mp * 100)|round(0) %}
             {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
             
             <div class="battle-unit enemy{% if not e.is_alive %} down{% endif %}"
@@ -27,8 +28,10 @@
                 <div class="member-info">
                     <div class="member-name">{{ e.name }}</div>
                     <div class="hp-bar"><div class="{{ hp_cls }}" style="width:{{ hp_pct }}%"></div></div>
+                    <div class="mp-bar"><div class="mp-fill" style="width:{{ mp_pct }}%"></div></div>
                 </div>
                 <div class="hp-text">{{ e.hp }}/{{ e.max_hp }}</div>
+                <div class="mp-text">{{ e.mp }}/{{ e.max_mp }}</div>
             </div>
         {% endfor %}
     </div>
@@ -39,11 +42,12 @@
         <div class="ally-party-display">
             {% for m in player_party %}
                 {% set hp_pct = (m.hp / m.max_hp * 100)|round(0) %}
-                {% set hp_cls = 'hp-fill' %}
-                {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
+            {% set hp_cls = 'hp-fill' %}
+            {% set mp_pct = (m.mp / m.max_mp * 100)|round(0) %}
+            {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
 
                 <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m is sameas current_actor %} active-turn{% endif %}"
-                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}">
+                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}" data-mp="{{ m.mp }}" data-max-mp="{{ m.max_mp }}">
                     
                     {% if m.image_filename %}
                         <img class="unit-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
@@ -51,8 +55,10 @@
                     <div class="member-info">
                         <div class="member-name">{{ m.name }}</div>
                         <div class="hp-bar"><div class="{{ hp_cls }}" style="width:{{ hp_pct }}%"></div></div>
+                        <div class="mp-bar"><div class="mp-fill" style="width:{{ mp_pct }}%"></div></div>
                     </div>
                     <div class="hp-text">{{ m.hp }}/{{ m.max_hp }}</div>
+                    <div class="mp-text">{{ m.mp }}/{{ m.max_mp }}</div>
                 </div>
             {% endfor %}
         </div>

--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -836,8 +836,26 @@ def battle(user_id):
         if request.method == 'POST':
             html = render_template('battle.html', messages=msgs, user_id=user_id)
             hp_vals = {
-                'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.player_party],
-                'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+                'player': [
+                    {
+                        'hp': m.hp,
+                        'max_hp': m.max_hp,
+                        'mp': m.mp,
+                        'max_mp': m.max_mp,
+                        'alive': m.is_alive,
+                    }
+                    for m in battle_obj.player_party
+                ],
+                'enemy': [
+                    {
+                        'hp': m.hp,
+                        'max_hp': m.max_hp,
+                        'mp': m.mp,
+                        'max_mp': m.max_mp,
+                        'alive': m.is_alive,
+                    }
+                    for m in battle_obj.enemy_party
+                ],
             }
             return jsonify({'hp_values': hp_vals, 'log': battle_obj.log, 'finished': True, 'turn': battle_obj.turn, 'html': html})
         return render_template('battle.html', messages=msgs, user_id=user_id)
@@ -845,8 +863,26 @@ def battle(user_id):
     current_actor = battle_obj.current_actor()
     if request.method == 'POST':
         hp_vals = {
-            'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.player_party],
-            'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+            'player': [
+                {
+                    'hp': m.hp,
+                    'max_hp': m.max_hp,
+                    'mp': m.mp,
+                    'max_mp': m.max_mp,
+                    'alive': m.is_alive,
+                }
+                for m in battle_obj.player_party
+            ],
+            'enemy': [
+                {
+                    'hp': m.hp,
+                    'max_hp': m.max_hp,
+                    'mp': m.mp,
+                    'max_mp': m.max_mp,
+                    'alive': m.is_alive,
+                }
+                for m in battle_obj.enemy_party
+            ],
         }
         actor = battle_obj.current_actor()
         actor_data = None


### PR DESCRIPTION
## Summary
- display MP bars under each unit's HP bar during battles
- update battle JavaScript to track and update MP
- extend CSS styles for the new MP bar
- send MP info from the server to the frontend

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bafd5ab50832182794519ec2ce482