### PR TITLE
Ensure command window stays visible

### DIFF
--- a/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -117,6 +117,9 @@ function setupBattleUI() {
                 });
         });
     }
+
+    const cmdWindow = document.querySelector('.command-window');
+    if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
 }
 
 function updateUnitList(units, infoList) {
@@ -221,6 +224,9 @@ function applyBattleData(data) {
         const activeUnit = Array.from(allyUnits).find(u => u.dataset.unitId === data.current_actor.unit_id);
         if (activeUnit) activeUnit.classList.add('active-turn');
     }
+
+    const cmdWindow = document.querySelector('.command-window');
+    if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
 }
 
 function showDamageIndicator(container, text) {


### PR DESCRIPTION
## Summary
- scroll the command window into view when the battle page loads
- keep the command window visible after applying new battle data

## Testing
- `pip install -r requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684bb4bf1028832185911e4b0656a110