### PR TITLE
Handle zero MP correctly

### DIFF
--- a/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -145,7 +145,7 @@ function updateUnitList(units, infoList) {
         if (text) text.textContent = info.hp + '/' + info.max_hp;
 
         const mpFill = unit.querySelector('.mp-fill');
-        const mpPct = Math.round(info.mp / info.max_mp * 100);
+        const mpPct = info.max_mp > 0 ? Math.round(info.mp / info.max_mp * 100) : 0;
         if (mpFill) {
             mpFill.style.width = mpPct + '%';
         }

--- a/src/monster_rpg/templates/battle_turn.html
+++ b/src/monster_rpg/templates/battle_turn.html
@@ -11,7 +11,7 @@
         {% for e in enemy_party %}
             {% set hp_pct = (e.hp / e.max_hp * 100)|round(0) %}
             {% set hp_cls = 'hp-fill' %}
-            {% set mp_pct = (e.mp / e.max_mp * 100)|round(0) %}
+            {% set mp_pct = ((e.mp / e.max_mp * 100) if e.max_mp > 0 else 0)|round(0) %}
             {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
             
             <div class="battle-unit enemy{% if not e.is_alive %} down{% endif %}"
@@ -41,7 +41,7 @@
             {% for m in player_party %}
                 {% set hp_pct = (m.hp / m.max_hp * 100)|round(0) %}
             {% set hp_cls = 'hp-fill' %}
-            {% set mp_pct = (m.mp / m.max_mp * 100)|round(0) %}
+            {% set mp_pct = ((m.mp / m.max_mp * 100) if m.max_mp > 0 else 0)|round(0) %}
             {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
 
                 <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m is sameas current_actor %} active-turn{% endif %}"


### PR DESCRIPTION
## Summary
- avoid division by zero for monsters with no MP on the battle turn page
- compute MP percentage conditionally in the battle JS logic

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2fbd11e083218f725eef81ba1d16