### PR TITLE
Fix post URL for battle form

### DIFF
--- a/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -94,7 +94,7 @@ function setupBattleUI() {
         form.addEventListener('submit', evt => {
             evt.preventDefault();
             const formData = new FormData(form);
-            const postUrl = "{{ url_for('battle', user_id=user_id) }}";
+            const postUrl = form.action;  // use the form's action URL
             const submitBtn = form.querySelector('button[type="submit"]');
             if (submitBtn) submitBtn.disabled = true;
             fetch(postUrl, { method: 'POST', body: formData })


### PR DESCRIPTION
## Summary
- use the form action as the post URL in `battle_turn.js`
- prevent Jinja templating from leaking into static JS

## Testing
- `pip install -e .`
- `pip install Flask`
- `pytest tests/test_web_battle_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c371e60ec8321a42ca1428426bd0f