### PR TITLE
Fix import behavior when Flask not installed

### DIFF
--- a/src/monster_rpg/web_main.py
+++ b/src/monster_rpg/web_main.py
@@ -11,7 +11,7 @@ try:
         session,
     )
 except ImportError as e:  # pragma: no cover - dependency check
-    raise SystemExit(
+    raise ImportError(
         "Flask is required to run this web interface. "
         "Install dependencies with 'pip install -r requirements.txt'."
     ) from e


### PR DESCRIPTION
## Summary
- avoid exiting the interpreter when importing `web_main` without Flask

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f71f6cd2c83219f82e8bdcb259def