### PR TITLE
Introduce effect system for skills and items

### DIFF
--- a/src/monster_rpg/battle.py
+++ b/src/monster_rpg/battle.py
@@ -5,11 +5,7 @@ from .player import Player  # Playerクラスは直接使わないが、型ヒ�
 from .monsters import Monster  # Monsterクラスのみ参照
 from .items.equipment import Equipment, EquipmentInstance
 from .skills.skills import Skill  # Skillクラスを参照
-from .skills.skill_actions import (
-    SKILL_EFFECT_MAP,
-    simple_attack,
-    simple_heal,
-)
+from .skills.skill_actions import apply_effects
 # import traceback # デバッグ時に必要なら再度有効化
 
 # 属性相性倍率定義
@@ -182,41 +178,14 @@ def apply_skill_effect(
             targets_to_use = [m for m in all_enemies if m.is_alive]
 
     for target in targets_to_use:  # スキルは複数の対象に影響することがある
-        if not target.is_alive:  # 対象が既に倒れていたらスキップ
+        if not target.is_alive:
             print(f"{target.name} は既に倒れているため、{skill_obj.name} の効果を受けなかった。")
             continue
 
-        effect_func = None
-        if isinstance(skill_obj.effect, str):
-            effect_func = SKILL_EFFECT_MAP.get(skill_obj.effect)
-
-        if effect_func is not None:
-            effect_func(caster, target, skill_obj, all_allies=all_allies, all_enemies=all_enemies)
-            continue
-
-        if callable(skill_obj.effect) and skill_obj.skill_type == "buff" and skill_obj.target == "ally":
-            try:
-                remove_func = skill_obj.effect(target)
-                if skill_obj.duration > 0:
-                    target.status_effects.append({
-                        "name": skill_obj.name,
-                        "remaining": skill_obj.duration,
-                        "remove_func": remove_func,
-                    })
-                print(f"{target.name} の何かが強化された！")
-            except Exception as e:
-                print(f"スキル効果の適用中にエラー: {e}")
-            continue
-
-        # フォールバック処理
-        if skill_obj.skill_type == "attack":
-            simple_attack(caster, target, skill_obj)
-        elif skill_obj.skill_type == "heal" and skill_obj.target == "ally":
-            simple_heal(caster, target, skill_obj)
-        elif skill_obj.skill_type in ("debuff", "status") and isinstance(skill_obj.effect, str):
-            apply_status(target, skill_obj.effect, skill_obj.duration)
+        if skill_obj.effects:
+            apply_effects(caster, target, skill_obj.effects)
         else:
-            print(f"スキル「{skill_obj.name}」は効果がなかった...")  # 未対応のスキルタイプなど
+            print(f"スキル「{skill_obj.name}」は効果がなかった...")
 
 def display_party_status(party: list[Monster], party_name: str):
     """パーティのステータスを表示します。"""

--- a/src/monster_rpg/items/item_data.py
+++ b/src/monster_rpg/items/item_data.py
@@ -1,12 +1,12 @@
 # Item definitions
 
 class Item:
-    def __init__(self, item_id, name, description, usable=False, effect=None):
+    def __init__(self, item_id, name, description, usable=False, effects=None):
         self.item_id = item_id
         self.name = name
         self.description = description
         self.usable = usable
-        self.effect = effect or {}
+        self.effects = effects or []
 
     def __repr__(self):
         return f"Item({self.item_id})"
@@ -17,7 +17,7 @@ small_potion = Item(
     name="スモールポーション",
     description="HPを少し回復する小さなポーション。",
     usable=True,
-    effect={"type": "heal_hp", "amount": 30},
+    effects=[{"type": "heal", "stat": "hp", "amount": 30}],
 )
 
 medium_potion = Item(
@@ -25,7 +25,7 @@ medium_potion = Item(
     name="ミディアムポーション",
     description="HPを中程度回復するポーション。",
     usable=True,
-    effect={"type": "heal_hp", "amount": 60},
+    effects=[{"type": "heal", "stat": "hp", "amount": 60}],
 )
 
 large_potion = Item(
@@ -33,7 +33,7 @@ large_potion = Item(
     name="ラージポーション",
     description="HPを大きく回復する高級ポーション。",
     usable=True,
-    effect={"type": "heal_hp", "amount": 120},
+    effects=[{"type": "heal", "stat": "hp", "amount": 120}],
 )
 
 ether = Item(
@@ -41,7 +41,7 @@ ether = Item(
     name="エーテル",
     description="MPを中程度回復する神秘の液体。",
     usable=True,
-    effect={"type": "heal_mp", "amount": 30},
+    effects=[{"type": "heal", "stat": "mp", "amount": 30}],
 )
 
 antidote = Item(
@@ -49,7 +49,7 @@ antidote = Item(
     name="アンチドート",
     description="毒状態を治療する解毒薬。",
     usable=True,
-    effect={"type": "cure_status", "status": "poison"},
+    effects=[{"type": "cure_status", "status": "poison"}],
 )
 
 elixir = Item(
@@ -57,7 +57,10 @@ elixir = Item(
     name="エリクサー",
     description="HPとMPを完全に回復する万能薬。",
     usable=True,
-    effect={"type": "heal_full"},
+    effects=[
+        {"type": "heal", "stat": "hp", "amount": "full"},
+        {"type": "heal", "stat": "mp", "amount": "full"},
+    ],
 )
 
 revive_scroll = Item(
@@ -65,7 +68,7 @@ revive_scroll = Item(
     name="リバイブスクロール",
     description="戦闘不能の味方1体を復活させる古文書。",
     usable=True,
-    effect={"type": "revive", "amount": "half"},
+    effects=[{"type": "revive", "amount": "half"}],
 )
 
 # ── モンスター合成素材 ──────────────────────────────

--- a/src/monster_rpg/items/item_effects.py
+++ b/src/monster_rpg/items/item_effects.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from .item_data import Item
+from ..skills.skill_actions import apply_effects
 
 if TYPE_CHECKING:
     from ..monsters.monster_class import Monster
@@ -17,81 +18,13 @@ def apply_item_effect(item: Item, target: Optional[Monster]) -> bool:
         print(f"{item.name} はここでは使えない。")
         return False
 
-    effect = getattr(item, "effect", {})
-    if not effect:
+    effects = getattr(item, "effects", [])
+    if not effects:
         print("このアイテムはまだ効果が実装されていない。")
         return False
-
-    etype = effect.get("type")
-
-    if etype == "heal_hp":
-        if target is None:
-            print("対象モンスターがいません。")
-            return False
-        if not target.is_alive:
-            print(f"{target.name} は倒れているため回復できない。")
-            return False
-        amount = effect.get("amount", 0)
-        before = target.hp
-        target.hp = min(target.max_hp, target.hp + amount)
-        healed = target.hp - before
-        print(f"{target.name} のHPが {healed} 回復した。")
-        return True
-
-    if etype == "heal_mp":
-        if target is None:
-            print("対象モンスターがいません。")
-            return False
-        amount = effect.get("amount", 0)
-        before = target.mp
-        target.mp = min(target.max_mp, target.mp + amount)
-        restored = target.mp - before
-        print(f"{target.name} のMPが {restored} 回復した。")
-        return True
-
-    if etype == "heal_full":
-        if target is None:
-            print("対象モンスターがいません。")
-            return False
-        if not target.is_alive:
-            print(f"{target.name} は倒れているため回復できない。")
-            return False
-        target.hp = target.max_hp
-        target.mp = target.max_mp
-        print(f"{target.name} のHPとMPが全回復した！")
-        return True
-
-    if etype == "revive":
-        if target is None:
-            print("対象モンスターがいません。")
-            return False
-        if target.is_alive:
-            print(f"{target.name} はまだ倒れていない。")
-            return False
-        target.is_alive = True
-        amount = effect.get("amount", "half")
-        if amount == "half":
-            target.hp = target.max_hp // 2
-        else:
-            try:
-                target.hp = min(target.max_hp, int(amount))
-            except (TypeError, ValueError):
-                target.hp = target.max_hp // 2
-        print(f"{target.name} が復活した！ HPが半分回復した。")
-        return True
-
-    if etype == "cure_status":
-        if target is None:
-            print("対象モンスターがいません。")
-            return False
-        status = effect.get("status")
-        before = len(target.status_effects)
-        target.status_effects = [e for e in target.status_effects if e["name"] != status]
-        if len(target.status_effects) < before:
-            print(f"{target.name} の {status} が治った。")
-            return True
-        print(f"{target.name} は {status} 状態ではない。")
+    if target is None:
+        print("対象モンスターがいません。")
         return False
-
-    print("このアイテムはまだ効果が実装されていない。")
-    return False
+    for eff in effects:
+        apply_effects(target, target, [eff])
+    return True

--- a/src/monster_rpg/monsters/monster_class.py
+++ b/src/monster_rpg/monsters/monster_class.py
@@ -179,6 +179,54 @@ class Monster:
                 bonus += e.total_speed
         return self.speed + bonus
 
+    # ------------------------------------------------------------------
+    # Effect helper methods
+    # ------------------------------------------------------------------
+    def heal(self, stat: str, amount):
+        if stat == 'hp':
+            if amount == 'full':
+                self.hp = self.max_hp
+            else:
+                before = self.hp
+                self.hp = min(self.max_hp, self.hp + int(amount))
+                healed = self.hp - before
+                if healed:
+                    print(f"{self.name} のHPが {healed} 回復した！ (HP: {self.hp})")
+        elif stat == 'mp':
+            if amount == 'full':
+                self.mp = self.max_mp
+            else:
+                before = self.mp
+                self.mp = min(self.max_mp, self.mp + int(amount))
+                restored = self.mp - before
+                if restored:
+                    print(f"{self.name} のMPが {restored} 回復した！ (MP: {self.mp})")
+
+    def apply_buff(self, stat: str, amount: int, duration: int) -> None:
+        if not stat:
+            return
+        setattr(self, stat, getattr(self, stat) + amount)
+
+        def revert(m: "Monster" = self, s: str = stat, a: int = amount) -> None:
+            setattr(m, s, getattr(m, s) - a)
+
+        if duration > 0:
+            self.status_effects.append({
+                'name': f'buff_{stat}',
+                'remaining': duration,
+                'remove_func': revert,
+            })
+
+    def apply_status(self, name: str, duration: int | None = None) -> None:
+        from ..battle import apply_status
+        apply_status(self, name, duration)
+
+    def cure_status(self, name: str) -> None:
+        before = len(self.status_effects)
+        self.status_effects = [e for e in self.status_effects if e['name'] != name]
+        if len(self.status_effects) < before:
+            print(f"{self.name} の {name} が治った。")
+
     @property
     def total_skills(self):
         skills = self.skills[:]

--- a/src/monster_rpg/skills/skills.py
+++ b/src/monster_rpg/skills/skills.py
@@ -1,11 +1,23 @@
 class Skill:
-    def __init__(self, name, power, cost=0, skill_type="attack", effect=None, target="enemy", scope="single", duration=0, description="", category=None):
+    def __init__(
+        self,
+        name,
+        power,
+        cost=0,
+        skill_type="attack",
+        effects=None,
+        target="enemy",
+        scope="single",
+        duration=0,
+        description="",
+        category=None,
+    ):
         """
         :param name: スキル名
         :param power: 威力（攻撃なら攻撃力に加算、回復なら回復量）
         :param cost: 消費MP
         :param skill_type: "attack", "heal", "buff", "debuff", "status"
-        :param effect: 特殊効果（関数や状態異常名など）
+        :param effects: 効果のリスト。各要素は{type: str, ...}形式の辞書
         :param target: "enemy" or "ally"（対象指定）
         :param scope: "single" or "all"（単体か全体か）
         :param duration: 効果持続ターン数（バフ等）
@@ -16,7 +28,7 @@ class Skill:
         self.power = power
         self.cost = cost
         self.skill_type = skill_type
-        self.effect = effect
+        self.effects = effects or []
         self.target = target
         self.scope = scope
         self.duration = duration
@@ -27,27 +39,9 @@ class Skill:
         scope_text = "全体" if self.scope == "all" else "単体"
         cost_text = f"MP:{self.cost}" if self.cost else ""
         return f"{self.name} ({self.skill_type}, Pow:{self.power}, {cost_text} {scope_text})"
-    # ------------------------------------------------------------
-# バフ／デバフ用 効果関数サンプル  （必要に応じて Monster クラス側で管理）
 # ------------------------------------------------------------
-def increase_attack(monster, amount=5):
-    monster.attack += amount
-    def revert():
-        monster.attack -= amount
-    return revert
-
-def increase_magic(monster, amount=5):
-    monster.magic += amount
-    def revert():
-        monster.magic -= amount
-    return revert
-
-def decrease_defense(monster, amount=5):
-    monster.defense -= amount
-    def revert():
-        monster.defense += amount
-    return revert
-
+# スキル定義
+# ------------------------------------------------------------
 
 # 攻撃スキル
 fireball = Skill(
@@ -55,7 +49,10 @@ fireball = Skill(
     power=30,
     cost=5,
     skill_type="attack",
-    effect="burn",
+    effects=[
+        {"type": "damage", "amount": 30},
+        {"type": "status", "status": "burn"},
+    ],
     description="火の玉で攻撃する",
     category="魔法",
 )
@@ -67,6 +64,7 @@ heal = Skill(
     cost=4,
     skill_type="heal",
     target="ally",
+    effects=[{"type": "heal", "stat": "hp", "amount": 25}],
     description="味方1体のHPを回復",
     category="回復",
 )
@@ -77,25 +75,20 @@ mass_heal = Skill(
     skill_type="heal",
     target="ally",
     scope="all",
+    effects=[{"type": "heal", "stat": "hp", "amount": 15}],
     description="味方全体を回復",
     category="回復",
 )
 
 # バフスキル
-def increase_defense(monster):
-    monster.defense += 5
-    def revert():
-        monster.defense -= 5
-    return revert
-
 guard_up = Skill(
     "ガードアップ",
     power=0,
     cost=3,
     skill_type="buff",
-    effect=increase_defense,
     target="ally",
     duration=3,
+    effects=[{"type": "buff", "stat": "defense", "amount": 5, "duration": 3}],
     description="数ターン防御力を上げる",
     category="補助",
 )
@@ -118,7 +111,10 @@ thunder_bolt = Skill(
     power=40,
     cost=6,
     skill_type="attack",
-    effect="paralyze",
+    effects=[
+        {"type": "damage", "amount": 40},
+        {"type": "status", "status": "paralyze"},
+    ],
     description="雷撃で攻撃し、稀に麻痺させる",
     category="魔法",
 )
@@ -128,7 +124,10 @@ ice_spear = Skill(
     power=35,
     cost=6,
     skill_type="attack",
-    effect="freeze",
+    effects=[
+        {"type": "damage", "amount": 35},
+        {"type": "status", "status": "freeze"},
+    ],
     description="氷の槍で貫き、低確率で凍結させる",
     category="魔法",
 )
@@ -138,6 +137,7 @@ wind_slash = Skill(
     power=28,
     cost=4,
     skill_type="attack",
+    effects=[{"type": "damage", "amount": 28}],
     description="鋭い風で切り裂く",
     category="物理",
 )
@@ -148,6 +148,7 @@ earth_quake = Skill(
     cost=9,
     skill_type="attack",
     scope="all",
+    effects=[{"type": "damage", "amount": 30}],
     description="大地を揺らし敵全体にダメージ",
     category="魔法",
 )
@@ -157,7 +158,10 @@ dark_pulse = Skill(
     power=32,
     cost=6,
     skill_type="attack",
-    effect="fear",
+    effects=[
+        {"type": "damage", "amount": 32},
+        {"type": "status", "status": "fear"},
+    ],
     description="闇の衝撃波で恐怖を与える",
     category="魔法",
 )
@@ -167,7 +171,10 @@ holy_light = Skill(
     power=38,
     cost=7,
     skill_type="attack",
-    effect="blind",
+    effects=[
+        {"type": "damage", "amount": 38},
+        {"type": "status", "status": "blind"},
+    ],
     description="聖なる光でダメージ＆失明を狙う",
     category="魔法",
 )
@@ -178,6 +185,7 @@ meteor_strike = Skill(
     cost=12,
     skill_type="attack",
     scope="all",
+    effects=[{"type": "damage", "amount": 50}],
     description="隕石を落とし敵全体に大ダメージ",
     category="魔法",
 )
@@ -187,7 +195,10 @@ poison_dart = Skill(
     power=18,
     cost=2,
     skill_type="attack",
-    effect="poison",
+    effects=[
+        {"type": "damage", "amount": 18},
+        {"type": "status", "status": "poison"},
+    ],
     description="毒針で攻撃し毒状態にする",
     category="物理",
 )
@@ -197,6 +208,7 @@ blade_rush = Skill(
     power=22,
     cost=3,
     skill_type="attack",
+    effects=[{"type": "damage", "amount": 22}],
     description="連続斬りでランダム敵を数回攻撃",
     category="物理",
 )
@@ -206,7 +218,10 @@ dragon_breath = Skill(
     power=45,
     cost=10,
     skill_type="attack",
-    effect="burn",
+    effects=[
+        {"type": "damage", "amount": 45},
+        {"type": "status", "status": "burn"},
+    ],
     scope="all",
     description="灼熱のブレスで敵全体を焼き払う",
     category="魔法",
@@ -219,6 +234,7 @@ cure = Skill(
     cost=6,
     skill_type="heal",
     target="ally",
+    effects=[{"type": "heal", "stat": "hp", "amount": 40}],
     description="味方1体を大きく回復",
     category="回復",
 )
@@ -230,7 +246,7 @@ regen = Skill(
     skill_type="buff",
     target="ally",
     duration=4,
-    effect="regen",          # 毎ターン回復フラグ等で管理
+    effects=[{"type": "status", "status": "regen", "duration": 4}],
     description="数ターンかけて徐々に回復",
     category="回復",
 )
@@ -241,7 +257,7 @@ revive = Skill(
     cost=15,
     skill_type="status",
     target="ally",
-    effect="revive",
+    effects=[{"type": "revive", "amount": "half"}],
     description="戦闘不能の味方をHP半分で復活",
     category="回復",
 )
@@ -254,7 +270,7 @@ power_up = Skill(
     skill_type="buff",
     target="ally",
     duration=3,
-    effect=increase_attack,
+    effects=[{"type": "buff", "stat": "attack", "amount": 5, "duration": 3}],
     description="攻撃力を上げる",
     category="補助",
 )
@@ -266,7 +282,7 @@ magic_boost = Skill(
     skill_type="buff",
     target="ally",
     duration=3,
-    effect=increase_magic,
+    effects=[{"type": "buff", "stat": "magic", "amount": 5, "duration": 3}],
     description="魔力を上げる",
     category="補助",
 )
@@ -278,7 +294,7 @@ speed_up = Skill(
     skill_type="buff",
     target="ally",
     duration=3,
-    effect="speed_up",
+    effects=[{"type": "buff", "stat": "speed", "amount": 5, "duration": 3}],
     description="素早さを上げる",
     category="補助",
 )
@@ -291,7 +307,10 @@ brave_song = Skill(
     target="ally",
     scope="all",
     duration=3,
-    effect="atk_def_up",
+    effects=[
+        {"type": "buff", "stat": "attack", "amount": 5, "duration": 3},
+        {"type": "buff", "stat": "defense", "amount": 5, "duration": 3},
+    ],
     description="戦意を高め味方全体の攻防を強化",
     category="補助",
 )
@@ -302,8 +321,8 @@ weaken_armor = Skill(
     power=0,
     cost=5,
     skill_type="debuff",
-    effect=decrease_defense,
     duration=3,
+    effects=[{"type": "buff", "stat": "defense", "amount": -5, "duration": 3}],
     description="敵の防御力を下げる",
     category="弱体",
 )
@@ -313,7 +332,7 @@ slow = Skill(
     power=0,
     cost=4,
     skill_type="debuff",
-    effect="slow",
+    effects=[{"type": "status", "status": "slow", "duration": 3}],
     duration=3,
     description="敵の素早さを下げる",
     category="弱体",
@@ -324,7 +343,7 @@ silence = Skill(
     power=0,
     cost=6,
     skill_type="debuff",
-    effect="silence",
+    effects=[{"type": "status", "status": "silence", "duration": 3}],
     duration=3,
     description="魔法を封じる",
     category="弱体",
@@ -335,7 +354,7 @@ curse = Skill(
     power=0,
     cost=8,
     skill_type="debuff",
-    effect="curse",
+    effects=[{"type": "status", "status": "curse", "duration": 4}],
     duration=4,
     description="呪いを付与し各種能力を低下",
     category="弱体",
@@ -347,7 +366,10 @@ stun_blow = Skill(
     power=20,
     cost=4,
     skill_type="attack",
-    effect="stun",
+    effects=[
+        {"type": "damage", "amount": 20},
+        {"type": "status", "status": "stun"},
+    ],
     description="殴打して気絶させる",
     category="物理",
 )
@@ -357,7 +379,7 @@ sleep_spell = Skill(
     power=0,
     cost=5,
     skill_type="status",
-    effect="sleep",
+    effects=[{"type": "status", "status": "sleep"}],
     description="敵を眠らせる魔法",
     category="魔法",
 )
@@ -367,7 +389,10 @@ paralysis_shock = Skill(
     power=25,
     cost=5,
     skill_type="attack",
-    effect="paralyze",
+    effects=[
+        {"type": "damage", "amount": 25},
+        {"type": "status", "status": "paralyze"},
+    ],
     description="痺れる衝撃で麻痺付与",
     category="魔法",
 )
@@ -378,7 +403,7 @@ confusion_gas = Skill(
     cost=6,
     skill_type="status",
     scope="all",
-    effect="confuse",
+    effects=[{"type": "status", "status": "confuse"}],
     description="混乱ガスで敵全体を混乱させる",
     category="魔法",
 )

--- a/tests/test_item_effects.py
+++ b/tests/test_item_effects.py
@@ -13,6 +13,28 @@ class DummyMonster:
         self.status_effects = []
         self.is_alive = True
 
+    # minimal helpers for effect system
+    def heal(self, stat, amount):
+        if stat == 'hp':
+            if amount == 'full':
+                self.hp = self.max_hp
+            else:
+                self.hp = min(self.max_hp, self.hp + int(amount))
+        elif stat == 'mp':
+            if amount == 'full':
+                self.mp = self.max_mp
+            else:
+                self.mp = min(self.max_mp, self.mp + int(amount))
+
+    def apply_buff(self, stat, amount, duration):
+        setattr(self, stat, getattr(self, stat) + amount)
+
+    def apply_status(self, name, duration=None):
+        self.status_effects.append({'name': name, 'remaining': duration or 1})
+
+    def cure_status(self, name):
+        self.status_effects = [e for e in self.status_effects if e['name'] != name]
+
 
 class ItemEffectFunctionTests(unittest.TestCase):
     def test_heal_hp_effect(self):

--- a/tests/test_skill_actions.py
+++ b/tests/test_skill_actions.py
@@ -1,6 +1,6 @@
 import unittest
 from monster_rpg.monsters.monster_class import Monster
-from monster_rpg.skills.skill_actions import SKILL_EFFECT_MAP, buff_atk_def_up
+from monster_rpg.skills.skill_actions import apply_effects
 from monster_rpg.battle import apply_skill_effect
 from monster_rpg.skills.skills import ALL_SKILLS, Skill
 
@@ -8,8 +8,8 @@ from monster_rpg.skills.skills import ALL_SKILLS, Skill
 class SkillActionIntegrationTests(unittest.TestCase):
     def test_status_mapping_poison(self):
         target = Monster('Target', hp=20, attack=5, defense=2)
-        skill = Skill('Poison', power=0, skill_type='status', effect='poison')
-        SKILL_EFFECT_MAP['poison'](None, target, skill)
+        skill = Skill('Poison', power=0, skill_type='status', effects=[{'type': 'status', 'status': 'poison'}])
+        apply_effects(target, target, skill.effects)
         self.assertTrue(any(e['name'] == 'poison' for e in target.status_effects))
 
     def test_brave_song_uses_buff_function(self):
@@ -17,19 +17,9 @@ class SkillActionIntegrationTests(unittest.TestCase):
         m2 = Monster('Ally', hp=30, attack=12, defense=12)
         allies = [m1, m2]
         skill = ALL_SKILLS['brave_song']
-        called = []
-        original = SKILL_EFFECT_MAP['atk_def_up']
-
-        def wrapper(caster, target, skill_obj, **kwargs):
-            called.append(target)
-            return original(caster, target, skill_obj, **kwargs)
-
-        SKILL_EFFECT_MAP['atk_def_up'] = wrapper
-        try:
-            apply_skill_effect(m1, [m1], skill, all_allies=allies)
-        finally:
-            SKILL_EFFECT_MAP['atk_def_up'] = original
-        self.assertEqual(len(called), 2)
+        apply_skill_effect(m1, [m1], skill, all_allies=allies)
+        self.assertEqual(m1.attack, 15)
+        self.assertEqual(m2.attack, 17)
 
 
 if __name__ == '__main__':

--- a/tests/test_status_effects.py
+++ b/tests/test_status_effects.py
@@ -9,8 +9,15 @@ class StatusEffectTests(unittest.TestCase):
     def test_poison_damage(self):
         target = Monster('Target', hp=20, attack=5, defense=2)
         attacker = Monster('Enemy', hp=20, attack=5, defense=2)
-        skill = Skill('TestPoison', power=0, cost=0, skill_type='status',
-                      effect='poison', target='enemy', duration=1)
+        skill = Skill(
+            'TestPoison',
+            power=0,
+            cost=0,
+            skill_type='status',
+            target='enemy',
+            duration=1,
+            effects=[{'type': 'status', 'status': 'poison', 'duration': 1}],
+        )
         apply_skill_effect(attacker, [target], skill)
         self.assertTrue(any(e['name'] == 'poison' for e in target.status_effects))
         process_status_effects(target)
@@ -31,7 +38,14 @@ class StatusEffectTests(unittest.TestCase):
             target = Monster("T", hp=20, attack=5, defense=2, speed=10)
             original_speed = target.speed
             attacker = Monster("E", hp=20, attack=5, defense=2)
-            skill = Skill("tmp", power=0, cost=0, skill_type="status", effect=status, target="enemy")
+            skill = Skill(
+                "tmp",
+                power=0,
+                cost=0,
+                skill_type="status",
+                target="enemy",
+                effects=[{'type': 'status', 'status': status}],
+            )
             apply_skill_effect(attacker, [target], skill)
             self.assertTrue(any(e["name"] == status for e in target.status_effects))
             duration = battle.STATUS_DEFINITIONS[status]["duration"]


### PR DESCRIPTION
## Summary
- extend `Skill` and `Item` definitions to store a list of effect dicts
- reimplement all skills and items with the new `effects` format
- add effect dispatchers and helper functions for monsters
- refactor battle and item logic to use the dispatcher
- adjust tests for the new system

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685269bcc5c483218620044a3096ed85