### PR TITLE
Externalize skills and items

### DIFF
--- a/README/README_EN.md
+++ b/README/README_EN.md
@@ -40,8 +40,9 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
 
 Use `monster_loader.load_monsters()` to read monster definitions from `monsters/monsters.json`. A `ValueError` is raised if the file is missing or contains invalid JSON.
 
-### Skills
-- `skills/skills.py` &mdash; defines the `Skill` class and several example skills. The dictionary `ALL_SKILLS` stores all available skills.
+### Skills and Items
+- `skills/skills.py` &mdash; defines the `Skill` class and loads definitions from `skills/skills.json`. The dictionary `ALL_SKILLS` stores all available skills.
+- `items/item_data.py` &mdash; defines the `Item` class and loads data from `items/items.json` as `ALL_ITEMS`.
 - `skills/__init__.py` &mdash; an empty module used to mark the directory as a package.
 
 ### Maps

--- a/README/README_JA.md
+++ b/README/README_JA.md
@@ -38,8 +38,9 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 
 `monsters/monsters.json` は JSON 形式のモンスター定義例です。`monster_loader.load_monsters()` を使うことで、ファイルからモンスターを一括読み込みできます。ファイルが存在しない、または JSON が不正な場合は `ValueError` が送出されます。
 
-### スキル
-- `skills/skills.py` — `Skill` クラスと複数の例示的なスキルを定義します。辞書 `ALL_SKILLS` に利用可能なスキルを格納しています。
+### スキルとアイテム
+- `skills/skills.py` — `Skill` クラスを定義し、`skills/skills.json` からスキル情報を読み込みます。辞書 `ALL_SKILLS` に利用可能なスキルを格納します。
+- `items/item_data.py` — `Item` クラスを定義し、`items/items.json` を読み込んで `ALL_ITEMS` を生成します。
 - `skills/__init__.py` — ディレクトリをパッケージとして扱うための空モジュールです。
 
 ### マップ

--- a/src/monster_rpg/items/items.json
+++ b/src/monster_rpg/items/items.json
@@ -1,0 +1,71 @@
+{
+  "small_potion": {
+    "name": "スモールポーション",
+    "description": "HPを少し回復する小さなポーション。",
+    "usable": true,
+    "effects": [{"type": "heal", "stat": "hp", "amount": 30}]
+  },
+  "medium_potion": {
+    "name": "ミディアムポーション",
+    "description": "HPを中程度回復するポーション。",
+    "usable": true,
+    "effects": [{"type": "heal", "stat": "hp", "amount": 60}]
+  },
+  "large_potion": {
+    "name": "ラージポーション",
+    "description": "HPを大きく回復する高級ポーション。",
+    "usable": true,
+    "effects": [{"type": "heal", "stat": "hp", "amount": 120}]
+  },
+  "ether": {
+    "name": "エーテル",
+    "description": "MPを中程度回復する神秘の液体。",
+    "usable": true,
+    "effects": [{"type": "heal", "stat": "mp", "amount": 30}]
+  },
+  "antidote": {
+    "name": "アンチドート",
+    "description": "毒状態を治療する解毒薬。",
+    "usable": true,
+    "effects": [{"type": "cure_status", "status": "poison"}]
+  },
+  "elixir": {
+    "name": "エリクサー",
+    "description": "HPとMPを完全に回復する万能薬。",
+    "usable": true,
+    "effects": [
+      {"type": "heal", "stat": "hp", "amount": "full"},
+      {"type": "heal", "stat": "mp", "amount": "full"}
+    ]
+  },
+  "revive_scroll": {
+    "name": "リバイブスクロール",
+    "description": "戦闘不能の味方1体を復活させる古文書。",
+    "usable": true,
+    "effects": [{"type": "revive", "amount": "half"}]
+  },
+  "magic_stone": {
+    "name": "魔石",
+    "description": "モンスター合成に用いられる不思議な石。合成研究所で特定の組み合わせに必須。"
+  },
+  "dragon_scale": {
+    "name": "ドラゴンスケイル",
+    "description": "若きドラゴンの鱗。強力な合成素材。"
+  },
+  "abyss_shard": {
+    "name": "アビスシャード",
+    "description": "闇の深淵で取れる黒水晶。ダークソウル系モンスターの合成に使う。"
+  },
+  "celestial_feather": {
+    "name": "セレスティアルフェザー",
+    "description": "光を宿す神鳥の羽根。高ランク合成素材。"
+  },
+  "thunder_core": {
+    "name": "サンダーコア",
+    "description": "強力な電気エネルギーを帯びた核。"
+  },
+  "frost_crystal": {
+    "name": "フロストクリスタル",
+    "description": "極寒地で採れる冷気を封じ込めた氷晶。"
+  }
+}

--- a/src/monster_rpg/skills/skills.json
+++ b/src/monster_rpg/skills/skills.json
@@ -1,0 +1,319 @@
+{
+  "fireball": {
+    "name": "ファイアボール",
+    "power": 30,
+    "cost": 5,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 30},
+      {"type": "status", "status": "burn"}
+    ],
+    "description": "火の玉で攻撃する",
+    "category": "魔法"
+  },
+  "heal": {
+    "name": "ヒール",
+    "power": 25,
+    "cost": 4,
+    "skill_type": "heal",
+    "target": "ally",
+    "effects": [{"type": "heal", "stat": "hp", "amount": 25}],
+    "description": "味方1体のHPを回復",
+    "category": "回復"
+  },
+  "mass_heal": {
+    "name": "ヒールオール",
+    "power": 15,
+    "cost": 8,
+    "skill_type": "heal",
+    "target": "ally",
+    "scope": "all",
+    "effects": [{"type": "heal", "stat": "hp", "amount": 15}],
+    "description": "味方全体を回復",
+    "category": "回復"
+  },
+  "guard_up": {
+    "name": "ガードアップ",
+    "power": 0,
+    "cost": 3,
+    "skill_type": "buff",
+    "target": "ally",
+    "duration": 3,
+    "effects": [{"type": "buff", "stat": "defense", "amount": 5, "duration": 3}],
+    "description": "数ターン防御力を上げる",
+    "category": "補助"
+  },
+  "thunder_bolt": {
+    "name": "サンダーボルト",
+    "power": 40,
+    "cost": 6,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 40},
+      {"type": "status", "status": "paralyze"}
+    ],
+    "description": "雷撃で攻撃し、稀に麻痺させる",
+    "category": "魔法"
+  },
+  "ice_spear": {
+    "name": "アイススピア",
+    "power": 35,
+    "cost": 6,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 35},
+      {"type": "status", "status": "freeze"}
+    ],
+    "description": "氷の槍で貫き、低確率で凍結させる",
+    "category": "魔法"
+  },
+  "wind_slash": {
+    "name": "ウィンドスラッシュ",
+    "power": 28,
+    "cost": 4,
+    "skill_type": "attack",
+    "effects": [{"type": "damage", "amount": 28}],
+    "description": "鋭い風で切り裂く",
+    "category": "物理"
+  },
+  "earth_quake": {
+    "name": "アースクエイク",
+    "power": 30,
+    "cost": 9,
+    "skill_type": "attack",
+    "scope": "all",
+    "effects": [{"type": "damage", "amount": 30}],
+    "description": "大地を揺らし敵全体にダメージ",
+    "category": "魔法"
+  },
+  "dark_pulse": {
+    "name": "ダークパルス",
+    "power": 32,
+    "cost": 6,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 32},
+      {"type": "status", "status": "fear"}
+    ],
+    "description": "闇の衝撃波で恐怖を与える",
+    "category": "魔法"
+  },
+  "holy_light": {
+    "name": "ホーリーライト",
+    "power": 38,
+    "cost": 7,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 38},
+      {"type": "status", "status": "blind"}
+    ],
+    "description": "聖なる光でダメージ＆失明を狙う",
+    "category": "魔法"
+  },
+  "meteor_strike": {
+    "name": "メテオストライク",
+    "power": 50,
+    "cost": 12,
+    "skill_type": "attack",
+    "scope": "all",
+    "effects": [{"type": "damage", "amount": 50}],
+    "description": "隕石を落とし敵全体に大ダメージ",
+    "category": "魔法"
+  },
+  "poison_dart": {
+    "name": "ポイズンダート",
+    "power": 18,
+    "cost": 2,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 18},
+      {"type": "status", "status": "poison"}
+    ],
+    "description": "毒針で攻撃し毒状態にする",
+    "category": "物理"
+  },
+  "blade_rush": {
+    "name": "ブレードラッシュ",
+    "power": 22,
+    "cost": 3,
+    "skill_type": "attack",
+    "effects": [{"type": "damage", "amount": 22}],
+    "description": "連続斬りでランダム敵を数回攻撃",
+    "category": "物理"
+  },
+  "dragon_breath": {
+    "name": "ドラゴンブレス",
+    "power": 45,
+    "cost": 10,
+    "skill_type": "attack",
+    "scope": "all",
+    "effects": [
+      {"type": "damage", "amount": 45},
+      {"type": "status", "status": "burn"}
+    ],
+    "description": "灼熱のブレスで敵全体を焼き払う",
+    "category": "魔法"
+  },
+  "cure": {
+    "name": "キュア",
+    "power": 40,
+    "cost": 6,
+    "skill_type": "heal",
+    "target": "ally",
+    "effects": [{"type": "heal", "stat": "hp", "amount": 40}],
+    "description": "味方1体を大きく回復",
+    "category": "回復"
+  },
+  "regen": {
+    "name": "リジェネ",
+    "power": 10,
+    "cost": 5,
+    "skill_type": "buff",
+    "target": "ally",
+    "duration": 4,
+    "effects": [{"type": "status", "status": "regen", "duration": 4}],
+    "description": "数ターンかけて徐々に回復",
+    "category": "回復"
+  },
+  "revive": {
+    "name": "リバイブ",
+    "power": 999,
+    "cost": 15,
+    "skill_type": "status",
+    "target": "ally",
+    "effects": [{"type": "revive", "amount": "half"}],
+    "description": "戦闘不能の味方をHP半分で復活",
+    "category": "回復"
+  },
+  "power_up": {
+    "name": "パワーアップ",
+    "power": 0,
+    "cost": 4,
+    "skill_type": "buff",
+    "target": "ally",
+    "duration": 3,
+    "effects": [{"type": "buff", "stat": "attack", "amount": 5, "duration": 3}],
+    "description": "攻撃力を上げる",
+    "category": "補助"
+  },
+  "magic_boost": {
+    "name": "マジックブースト",
+    "power": 0,
+    "cost": 4,
+    "skill_type": "buff",
+    "target": "ally",
+    "duration": 3,
+    "effects": [{"type": "buff", "stat": "magic", "amount": 5, "duration": 3}],
+    "description": "魔力を上げる",
+    "category": "補助"
+  },
+  "speed_up": {
+    "name": "スピードアップ",
+    "power": 0,
+    "cost": 3,
+    "skill_type": "buff",
+    "target": "ally",
+    "duration": 3,
+    "effects": [{"type": "buff", "stat": "speed", "amount": 5, "duration": 3}],
+    "description": "素早さを上げる",
+    "category": "補助"
+  },
+  "brave_song": {
+    "name": "ブレイブソング",
+    "power": 0,
+    "cost": 7,
+    "skill_type": "buff",
+    "target": "ally",
+    "scope": "all",
+    "duration": 3,
+    "effects": [
+      {"type": "buff", "stat": "attack", "amount": 5, "duration": 3},
+      {"type": "buff", "stat": "defense", "amount": 5, "duration": 3}
+    ],
+    "description": "戦意を高め味方全体の攻防を強化",
+    "category": "補助"
+  },
+  "weaken_armor": {
+    "name": "ウィークンアーマー",
+    "power": 0,
+    "cost": 5,
+    "skill_type": "debuff",
+    "duration": 3,
+    "effects": [{"type": "buff", "stat": "defense", "amount": -5, "duration": 3}],
+    "description": "敵の防御力を下げる",
+    "category": "弱体"
+  },
+  "slow": {
+    "name": "スロウ",
+    "power": 0,
+    "cost": 4,
+    "skill_type": "debuff",
+    "effects": [{"type": "status", "status": "slow", "duration": 3}],
+    "duration": 3,
+    "description": "敵の素早さを下げる",
+    "category": "弱体"
+  },
+  "silence": {
+    "name": "サイレンス",
+    "power": 0,
+    "cost": 6,
+    "skill_type": "debuff",
+    "effects": [{"type": "status", "status": "silence", "duration": 3}],
+    "duration": 3,
+    "description": "魔法を封じる",
+    "category": "弱体"
+  },
+  "curse": {
+    "name": "カース",
+    "power": 0,
+    "cost": 8,
+    "skill_type": "debuff",
+    "effects": [{"type": "status", "status": "curse", "duration": 4}],
+    "duration": 4,
+    "description": "呪いを付与し各種能力を低下",
+    "category": "弱体"
+  },
+  "stun_blow": {
+    "name": "スタンブロウ",
+    "power": 20,
+    "cost": 4,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 20},
+      {"type": "status", "status": "stun"}
+    ],
+    "description": "殴打して気絶させる",
+    "category": "物理"
+  },
+  "sleep_spell": {
+    "name": "スリープ",
+    "power": 0,
+    "cost": 5,
+    "skill_type": "status",
+    "effects": [{"type": "status", "status": "sleep"}],
+    "description": "敵を眠らせる魔法",
+    "category": "魔法"
+  },
+  "paralysis_shock": {
+    "name": "パラライズショック",
+    "power": 25,
+    "cost": 5,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "damage", "amount": 25},
+      {"type": "status", "status": "paralyze"}
+    ],
+    "description": "痺れる衝撃で麻痺付与",
+    "category": "魔法"
+  },
+  "confusion_gas": {
+    "name": "コンフュージョンガス",
+    "power": 0,
+    "cost": 6,
+    "skill_type": "status",
+    "scope": "all",
+    "effects": [{"type": "status", "status": "confuse"}],
+    "description": "混乱ガスで敵全体を混乱させる",
+    "category": "魔法"
+  }
+}

--- a/src/monster_rpg/skills/skills.py
+++ b/src/monster_rpg/skills/skills.py
@@ -1,29 +1,28 @@
+"""Skill class and JSON loader."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Any
+
+
 class Skill:
+    """Represents an ability usable in battle."""
+
     def __init__(
         self,
-        name,
-        power,
-        cost=0,
-        skill_type="attack",
-        effects=None,
-        target="enemy",
-        scope="single",
-        duration=0,
-        description="",
-        category=None,
-    ):
-        """
-        :param name: スキル名
-        :param power: 威力（攻撃なら攻撃力に加算、回復なら回復量）
-        :param cost: 消費MP
-        :param skill_type: "attack", "heal", "buff", "debuff", "status"
-        :param effects: 効果のリスト。各要素は{type: str, ...}形式の辞書
-        :param target: "enemy" or "ally"（対象指定）
-        :param scope: "single" or "all"（単体か全体か）
-        :param duration: 効果持続ターン数（バフ等）
-        :param description: 説明文
-        :param category: スキル分類（物理/魔法など）
-        """
+        name: str,
+        power: int,
+        cost: int = 0,
+        skill_type: str = "attack",
+        effects: List[dict] | None = None,
+        target: str = "enemy",
+        scope: str = "single",
+        duration: int = 0,
+        description: str = "",
+        category: str | None = None,
+    ) -> None:
         self.name = name
         self.power = power
         self.cost = cost
@@ -35,411 +34,44 @@ class Skill:
         self.description = description
         self.category = category
 
-    def describe(self):
+    def describe(self) -> str:  # pragma: no cover - simple helper
         scope_text = "全体" if self.scope == "all" else "単体"
         cost_text = f"MP:{self.cost}" if self.cost else ""
         return f"{self.name} ({self.skill_type}, Pow:{self.power}, {cost_text} {scope_text})"
-# ------------------------------------------------------------
-# スキル定義
-# ------------------------------------------------------------
 
-# 攻撃スキル
-fireball = Skill(
-    "ファイアボール",
-    power=30,
-    cost=5,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 30},
-        {"type": "status", "status": "burn"},
-    ],
-    description="火の玉で攻撃する",
-    category="魔法",
-)
 
-# 回復スキル
-heal = Skill(
-    "ヒール",
-    power=25,
-    cost=4,
-    skill_type="heal",
-    target="ally",
-    effects=[{"type": "heal", "stat": "hp", "amount": 25}],
-    description="味方1体のHPを回復",
-    category="回復",
-)
-mass_heal = Skill(
-    "ヒールオール",
-    power=15,
-    cost=8,
-    skill_type="heal",
-    target="ally",
-    scope="all",
-    effects=[{"type": "heal", "stat": "hp", "amount": 15}],
-    description="味方全体を回復",
-    category="回復",
-)
+def load_skills(filepath: str | None = None) -> Dict[str, Skill]:
+    """Load skills from a JSON file."""
+    if filepath is None:
+        filepath = os.path.join(os.path.dirname(__file__), "skills.json")
 
-# バフスキル
-guard_up = Skill(
-    "ガードアップ",
-    power=0,
-    cost=3,
-    skill_type="buff",
-    target="ally",
-    duration=3,
-    effects=[{"type": "buff", "stat": "defense", "amount": 5, "duration": 3}],
-    description="数ターン防御力を上げる",
-    category="補助",
-)
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            text = f.read().replace("\u00a0", " ")
+    except FileNotFoundError as e:
+        raise ValueError(f"Skill data file not found: {filepath}") from e
 
-ALL_SKILLS = {
-    "fireball": fireball,
-    "heal": heal,
-    "guard_up": guard_up,
-    "mass_heal": mass_heal,
-    # 新しいスキルを追加したら、ここにも追記していきます
-    # "thunder_bolt": thunder_bolt, # 例えば
-}
+    try:
+        data: Dict[str, Any] = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid skill data JSON in {filepath}") from e
 
-# ------------------------------------------------------------
-# 追加スキル定義
-# ------------------------------------------------------------
-# 1) 攻撃系 ──────────────────────────────────────────
-thunder_bolt = Skill(
-    "サンダーボルト",
-    power=40,
-    cost=6,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 40},
-        {"type": "status", "status": "paralyze"},
-    ],
-    description="雷撃で攻撃し、稀に麻痺させる",
-    category="魔法",
-)
+    skills: Dict[str, Skill] = {}
+    for skill_id, attrs in data.items():
+        skills[skill_id] = Skill(
+            name=attrs.get("name", skill_id),
+            power=attrs.get("power", 0),
+            cost=attrs.get("cost", 0),
+            skill_type=attrs.get("skill_type", "attack"),
+            effects=attrs.get("effects", []),
+            target=attrs.get("target", "enemy"),
+            scope=attrs.get("scope", "single"),
+            duration=attrs.get("duration", 0),
+            description=attrs.get("description", ""),
+            category=attrs.get("category"),
+        )
+    return skills
 
-ice_spear = Skill(
-    "アイススピア",
-    power=35,
-    cost=6,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 35},
-        {"type": "status", "status": "freeze"},
-    ],
-    description="氷の槍で貫き、低確率で凍結させる",
-    category="魔法",
-)
 
-wind_slash = Skill(
-    "ウィンドスラッシュ",
-    power=28,
-    cost=4,
-    skill_type="attack",
-    effects=[{"type": "damage", "amount": 28}],
-    description="鋭い風で切り裂く",
-    category="物理",
-)
-
-earth_quake = Skill(
-    "アースクエイク",
-    power=30,
-    cost=9,
-    skill_type="attack",
-    scope="all",
-    effects=[{"type": "damage", "amount": 30}],
-    description="大地を揺らし敵全体にダメージ",
-    category="魔法",
-)
-
-dark_pulse = Skill(
-    "ダークパルス",
-    power=32,
-    cost=6,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 32},
-        {"type": "status", "status": "fear"},
-    ],
-    description="闇の衝撃波で恐怖を与える",
-    category="魔法",
-)
-
-holy_light = Skill(
-    "ホーリーライト",
-    power=38,
-    cost=7,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 38},
-        {"type": "status", "status": "blind"},
-    ],
-    description="聖なる光でダメージ＆失明を狙う",
-    category="魔法",
-)
-
-meteor_strike = Skill(
-    "メテオストライク",
-    power=50,
-    cost=12,
-    skill_type="attack",
-    scope="all",
-    effects=[{"type": "damage", "amount": 50}],
-    description="隕石を落とし敵全体に大ダメージ",
-    category="魔法",
-)
-
-poison_dart = Skill(
-    "ポイズンダート",
-    power=18,
-    cost=2,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 18},
-        {"type": "status", "status": "poison"},
-    ],
-    description="毒針で攻撃し毒状態にする",
-    category="物理",
-)
-
-blade_rush = Skill(
-    "ブレードラッシュ",
-    power=22,
-    cost=3,
-    skill_type="attack",
-    effects=[{"type": "damage", "amount": 22}],
-    description="連続斬りでランダム敵を数回攻撃",
-    category="物理",
-)
-
-dragon_breath = Skill(
-    "ドラゴンブレス",
-    power=45,
-    cost=10,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 45},
-        {"type": "status", "status": "burn"},
-    ],
-    scope="all",
-    description="灼熱のブレスで敵全体を焼き払う",
-    category="魔法",
-)
-
-# 2) 回復系 ──────────────────────────────────────────
-cure = Skill(
-    "キュア",
-    power=40,
-    cost=6,
-    skill_type="heal",
-    target="ally",
-    effects=[{"type": "heal", "stat": "hp", "amount": 40}],
-    description="味方1体を大きく回復",
-    category="回復",
-)
-
-regen = Skill(
-    "リジェネ",
-    power=10,
-    cost=5,
-    skill_type="buff",
-    target="ally",
-    duration=4,
-    effects=[{"type": "status", "status": "regen", "duration": 4}],
-    description="数ターンかけて徐々に回復",
-    category="回復",
-)
-
-revive = Skill(
-    "リバイブ",
-    power=999,               # 特殊扱い
-    cost=15,
-    skill_type="status",
-    target="ally",
-    effects=[{"type": "revive", "amount": "half"}],
-    description="戦闘不能の味方をHP半分で復活",
-    category="回復",
-)
-
-# 3) バフ系 ──────────────────────────────────────────
-power_up = Skill(
-    "パワーアップ",
-    power=0,
-    cost=4,
-    skill_type="buff",
-    target="ally",
-    duration=3,
-    effects=[{"type": "buff", "stat": "attack", "amount": 5, "duration": 3}],
-    description="攻撃力を上げる",
-    category="補助",
-)
-
-magic_boost = Skill(
-    "マジックブースト",
-    power=0,
-    cost=4,
-    skill_type="buff",
-    target="ally",
-    duration=3,
-    effects=[{"type": "buff", "stat": "magic", "amount": 5, "duration": 3}],
-    description="魔力を上げる",
-    category="補助",
-)
-
-speed_up = Skill(
-    "スピードアップ",
-    power=0,
-    cost=3,
-    skill_type="buff",
-    target="ally",
-    duration=3,
-    effects=[{"type": "buff", "stat": "speed", "amount": 5, "duration": 3}],
-    description="素早さを上げる",
-    category="補助",
-)
-
-brave_song = Skill(
-    "ブレイブソング",
-    power=0,
-    cost=7,
-    skill_type="buff",
-    target="ally",
-    scope="all",
-    duration=3,
-    effects=[
-        {"type": "buff", "stat": "attack", "amount": 5, "duration": 3},
-        {"type": "buff", "stat": "defense", "amount": 5, "duration": 3},
-    ],
-    description="戦意を高め味方全体の攻防を強化",
-    category="補助",
-)
-
-# 4) デバフ系 ──────────────────────────────────────────
-weaken_armor = Skill(
-    "ウィークンアーマー",
-    power=0,
-    cost=5,
-    skill_type="debuff",
-    duration=3,
-    effects=[{"type": "buff", "stat": "defense", "amount": -5, "duration": 3}],
-    description="敵の防御力を下げる",
-    category="弱体",
-)
-
-slow = Skill(
-    "スロウ",
-    power=0,
-    cost=4,
-    skill_type="debuff",
-    effects=[{"type": "status", "status": "slow", "duration": 3}],
-    duration=3,
-    description="敵の素早さを下げる",
-    category="弱体",
-)
-
-silence = Skill(
-    "サイレンス",
-    power=0,
-    cost=6,
-    skill_type="debuff",
-    effects=[{"type": "status", "status": "silence", "duration": 3}],
-    duration=3,
-    description="魔法を封じる",
-    category="弱体",
-)
-
-curse = Skill(
-    "カース",
-    power=0,
-    cost=8,
-    skill_type="debuff",
-    effects=[{"type": "status", "status": "curse", "duration": 4}],
-    duration=4,
-    description="呪いを付与し各種能力を低下",
-    category="弱体",
-)
-
-# 5) 状態異常系（直接付与）─────────────────────────────
-stun_blow = Skill(
-    "スタンブロウ",
-    power=20,
-    cost=4,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 20},
-        {"type": "status", "status": "stun"},
-    ],
-    description="殴打して気絶させる",
-    category="物理",
-)
-
-sleep_spell = Skill(
-    "スリープ",
-    power=0,
-    cost=5,
-    skill_type="status",
-    effects=[{"type": "status", "status": "sleep"}],
-    description="敵を眠らせる魔法",
-    category="魔法",
-)
-
-paralysis_shock = Skill(
-    "パラライズショック",
-    power=25,
-    cost=5,
-    skill_type="attack",
-    effects=[
-        {"type": "damage", "amount": 25},
-        {"type": "status", "status": "paralyze"},
-    ],
-    description="痺れる衝撃で麻痺付与",
-    category="魔法",
-)
-
-confusion_gas = Skill(
-    "コンフュージョンガス",
-    power=0,
-    cost=6,
-    skill_type="status",
-    scope="all",
-    effects=[{"type": "status", "status": "confuse"}],
-    description="混乱ガスで敵全体を混乱させる",
-    category="魔法",
-)
-
-# ------------------------------------------------------------
-# ALL_SKILLS に追加（既存辞書の下で実行）
-# ------------------------------------------------------------
-ALL_SKILLS.update({
-    # 攻撃
-    "thunder_bolt": thunder_bolt,
-    "ice_spear": ice_spear,
-    "wind_slash": wind_slash,
-    "earth_quake": earth_quake,
-    "dark_pulse": dark_pulse,
-    "holy_light": holy_light,
-    "meteor_strike": meteor_strike,
-    "poison_dart": poison_dart,
-    "blade_rush": blade_rush,
-    "dragon_breath": dragon_breath,
-    # 回復
-    "cure": cure,
-    "regen": regen,
-    "revive": revive,
-    # バフ
-    "power_up": power_up,
-    "magic_boost": magic_boost,
-    "speed_up": speed_up,
-    "brave_song": brave_song,
-    # デバフ
-    "weaken_armor": weaken_armor,
-    "slow": slow,
-    "silence": silence,
-    "curse": curse,
-    # 状態異常
-    "stun_blow": stun_blow,
-    "sleep_spell": sleep_spell,
-    "paralysis_shock": paralysis_shock,
-    "confusion_gas": confusion_gas,
-})
+# Load default skills on import
+ALL_SKILLS: Dict[str, Skill] = load_skills()


### PR DESCRIPTION
## Summary
- load items from `items/items.json`
- load skills from `skills/skills.json`
- document the new JSON files in both English and Japanese READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526c44b2208321819b045bbd88ce74