### PR TITLE
Add item/skill JSONs to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
             'static/**/*',
             'monsters/*.json',
             'map/*.json',
+            'items/*.json',
+            'skills/*.json',
         ]
     },
 )


### PR DESCRIPTION
## Summary
- include `items/*.json` and `skills/*.json` in package data

## Testing
- `python setup.py sdist`


------
https://chatgpt.com/codex/tasks/task_e_685274efe38c832184fd3739dc3b3cbe