### PR TITLE
Add networkx and matplotlib dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+networkx
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,9 @@ setup(
             'skills/*.json',
         ]
     },
+    install_requires=[
+        'Flask',
+        'networkx',
+        'matplotlib'
+    ],
 )


### PR DESCRIPTION
## Summary
- include `networkx` and `matplotlib` in `requirements.txt`
- register these packages in `setup.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527ba3def083219c2951c76e3b0e50