### PR TITLE
Fix docker-compose volume syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,4 @@ services:
 
 # トップレベルで名前付きボリュームを定義
 volumes:
-  postgres_data
+  postgres_data:


### PR DESCRIPTION
## Summary
- fix `volumes` block syntax in `docker-compose.yml`
- ensure YAML parses correctly

## Testing
- `python3 - <<'EOF'
import yaml, json
print(json.dumps(yaml.safe_load(open('docker-compose.yml')), indent=2))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685351cf7c808321971acbb044777d76