### PR TITLE
Drop unused PostgreSQL config

### DIFF
--- a/backend/README/README_EN.md
+++ b/backend/README/README_EN.md
@@ -3,7 +3,7 @@
 This is a small text-based RPG prototype written in Python. It uses SQLite to store simple save data and now supports multiple user accounts. A minimal Flask web server is also included.
 
 > **Note**
-> The provided `docker-compose.yml` file defines a `DATABASE_URL` pointing to a PostgreSQL container. The Python application currently ignores this variable and always uses the local SQLite database `monster_rpg_save.db`.
+> The `docker-compose.yml` file simply launches the Flask backend and no longer includes a PostgreSQL service. The game continues to use the local SQLite database `monster_rpg_save.db`.
 
 ## Requirements
 - Python 3 (tested with Python 3.11)
@@ -36,14 +36,14 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
 
 ## Running with Docker
 
-The repository includes a `docker-compose.yml` for a sample Postgres + Flask setup. Build the images then launch the containers:
+The repository includes a `docker-compose.yml` that starts the Flask backend using SQLite. Build the image and launch the container:
 
 ```bash
 docker-compose build
 docker-compose up
 ```
 
-The backend service exposes port 5000. Source files under `./backend/src` are mounted into the container. Database data is stored in the named volume `postgres_data`. The `DATABASE_URL` variable in `docker-compose.yml` sets the connection string for the app (currently ignored by the Python code).
+The backend service exposes port 5000 and mounts `./backend/src` into the container so code changes are reflected immediately.
 
 ## Project Structure
 

--- a/backend/README/README_JA.md
+++ b/backend/README/README_JA.md
@@ -3,7 +3,7 @@
 Pythonで作られた小さなテキストベースRPGのプロトタイプです。SQLiteを利用してシンプルなセーブデータを保存し、複数のユーザーアカウントにも対応しています。最小構成のFlaskウェブサーバーも同梱されています。
 
 > **補足**
-> `docker-compose.yml` では PostgreSQL コンテナを指す `DATABASE_URL` が設定されていますが、Python コードは現時点でこの変数を参照せず、常にローカルの SQLite データベース `monster_rpg_save.db` を使用します。
+> `docker-compose.yml` は Flask バックエンドを起動するだけで、PostgreSQL サービスは含まれていません。ゲームは引き続きローカルの SQLite データベース `monster_rpg_save.db` を利用します。
 
 ## 必要環境
 - Python 3 (検証済み: 3.11)
@@ -34,14 +34,14 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
 
 ## Dockerでの実行
 
-リポジトリにはサンプルのPostgreSQL+Flask環境を用意した `docker-compose.yml` が含まれています。以下のコマンドでイメージをビルドし、コンテナを起動します。
+リポジトリには Flask バックエンドを SQLite で起動する `docker-compose.yml` が用意されています。以下のコマンドでイメージをビルドし、コンテナを起動します。
 
 ```bash
 docker-compose build
 docker-compose up
 ```
 
-バックエンドサービスは5000番ポートを公開します。`./backend/src` をコンテナ内 `/app` としてマウントし、データベースのデータは名前付きボリューム `postgres_data` に保存されます。`docker-compose.yml` 内の `DATABASE_URL` 変数はアプリの接続先を示します（Pythonコードでは現在使用されていません）。
+バックエンドサービスは5000番ポートを公開します。`./backend/src` をコンテナ内 `/app` としてマウントするため、コードの変更が即時反映されます。
 
 ## プロジェクト構成
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,25 +9,4 @@ services:
       - "5000:5000"  # PCの5000番ポートとコンテナの5000番ポートを繋ぐ
     volumes:
       - ./backend/src:/app  # PCのソースコードの変更をコンテナに即時反映させる
-    environment:
-      # DB接続情報を環境変数として定義
-      - DATABASE_URL=postgresql://user:password@db:5432/monster_rpg_db
-    depends_on:
-      - db  # dbサービスが起動してから、backendを起動する
 
-  # データベースのサービス
-  db:
-    image: postgres:13-alpine  # PostgreSQLの軽量イメージを使用
-    volumes:
-      # DBのデータをPC上に保存し、コンテナを消してもデータが消えないようにする
-      - postgres_data:/var/lib/postgresql/data/
-    environment:
-      - POSTGRES_USER=user
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_DB=monster_rpg_db
-    ports:
-      - "5432:5432"
-
-# トップレベルで名前付きボリュームを定義
-volumes:
-  postgres_data:


### PR DESCRIPTION
## Summary
- remove the PostgreSQL service from `docker-compose.yml`
- clarify that Docker uses SQLite in English and Japanese READMEs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535374b66483218739f0ef4ef679b3