### PR TITLE
Add dockerignore for backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+# .dockerignore
+__pycache__/
+*.pyc
+tests/
+README/
+


### PR DESCRIPTION
## Summary
- reduce Docker build context for backend
- create `.dockerignore` with common ignores

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'monster_rpg')*

------
https://chatgpt.com/codex/tasks/task_e_685354ad2d8883218d6360cbf71fd6d1