### PR TITLE
Allow setting flask secret key

### DIFF
--- a/backend/README/README_EN.md
+++ b/backend/README/README_EN.md
@@ -27,12 +27,14 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
    `webapp.py` exposes only a couple JSON endpoints (like `/new_game` and
    `/load_game`) and does not include the battle system.
 4. Another web interface exists. Use the provided launcher script:
-   ```bash
+  ```bash
    pip install -r requirements.txt
    python -m monster_rpg.start_rpg
    ```
    This starts the server at <http://localhost:5000/> using Flask templates
    and provides the full game including battles.
+   Set the `FLASK_SECRET_KEY` environment variable to customize the
+   Flask secret key (defaults to `dev-secret`).
 
 ## Running with Docker
 

--- a/backend/README/README_JA.md
+++ b/backend/README/README_JA.md
@@ -27,10 +27,11 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
    `webapp.py` は `/new_game` や `/load_game` といった最低限のJSON APIのみを提供し、戦闘機能は含まれていません。
 4. `start_rpg.py` を使うと、完全なウェブ版を起動できます:
    ```bash
-   pip install -r requirements.txt
-   python -m monster_rpg.start_rpg
-   ```
-   これにより <http://localhost:5000/> でサーバーが起動し、Flaskテンプレートを使用した画面で戦闘を含む完全なゲームを楽しめます。
+  pip install -r requirements.txt
+  python -m monster_rpg.start_rpg
+  ```
+  これにより <http://localhost:5000/> でサーバーが起動し、Flaskテンプレートを使用した画面で戦闘を含む完全なゲームを楽しめます。
+  `FLASK_SECRET_KEY` 環境変数を設定することで Flask の secret key を変更できます。未設定の場合は `dev-secret` が使用されます。
 
 ## Dockerでの実行
 

--- a/backend/src/monster_rpg/web_main.py
+++ b/backend/src/monster_rpg/web_main.py
@@ -16,6 +16,7 @@ except ImportError as e:  # pragma: no cover - dependency check
         "Install dependencies with 'pip install -r requirements.txt'."
     ) from e
 import random
+import os
 
 import sqlite3
 from . import database_setup
@@ -28,7 +29,7 @@ from .map_data import LOCATIONS, get_map_overview, get_map_grid, load_locations
 from .exploration import generate_enemy_party
 
 app = Flask(__name__)
-app.secret_key = "dev-secret"
+app.secret_key = os.getenv("FLASK_SECRET_KEY", "dev-secret")
 
 database_setup.initialize_database()
 load_locations()


### PR DESCRIPTION
## Summary
- read app.secret_key from FLASK_SECRET_KEY
- document the new environment variable in English and Japanese READMEs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68535cf0dad08321bd60a2470a56ad7e