### PR TITLE
Allow database filename override

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ This repository provides README files in multiple languages:
 
 - [English](backend/README/README_EN.md)
 - [日本語](backend/README/README_JA.md)
+
+Set the environment variable `MONSTER_RPG_DB` to change where the game saves
+its SQLite database.

--- a/backend/README/README_EN.md
+++ b/backend/README/README_EN.md
@@ -18,6 +18,8 @@ This is a small text-based RPG prototype written in Python. It uses SQLite to st
    python -m monster_rpg.database_setup
    ```
    This creates `monster_rpg_save.db` if it does not already exist.
+   Set the `MONSTER_RPG_DB` environment variable to use a different
+   location for the SQLite save file.
    A default user `player1` will be created automatically. Use `database_setup.create_user()` to add more users.
 3. To run the simple web server instead:
    ```bash
@@ -98,8 +100,9 @@ Other notable modules include `player.py` (player data and save/load logic), `ba
   where you left off.
 
 ## Saving
-The game saves player data to `monster_rpg_save.db`. Monster HP/MP values now
-persist across sessions. If you upgrade the game, run
+The game saves player data to `monster_rpg_save.db` by default. You can
+override the filename by setting the `MONSTER_RPG_DB` environment variable.
+Monster HP/MP values now persist across sessions. If you upgrade the game, run
 `python -m monster_rpg.database_setup` again (or call
 `database_setup.initialize_database()` in code) to add any new columns and
 tables, such as the HP/MP fields or the `exploration_progress` table, to

--- a/backend/README/README_JA.md
+++ b/backend/README/README_JA.md
@@ -18,6 +18,7 @@ Pythonで作られた小さなテキストベースRPGのプロトタイプで�
    python -m monster_rpg.database_setup
    ```
    既に存在しない場合 `monster_rpg_save.db` が作成されます。
+   環境変数 `MONSTER_RPG_DB` を設定すると保存先を変更できます。
    デフォルトユーザー `player1` が自動で作成されます。追加ユーザーを作る場合は `database_setup.create_user()` を利用してください。
 3. 代わりに簡易ウェブサーバーを起動するには:
    ```bash
@@ -91,7 +92,7 @@ docker-compose up
 - セーブ時にモンスターのHPとMPも保存されるため、続きから再開しても状態が維持されます。
 
 ## セーブについて
-プレイヤーデータは `monster_rpg_save.db` に保存されます。モンスターのHP/MPもセーブされるようになり、前回の状態を維持したまま再開できます。
+プレイヤーデータは `monster_rpg_save.db` に保存されます。環境変数 `MONSTER_RPG_DB` を使えばファイル名を変更できます。モンスターのHP/MPもセーブされるようになり、前回の状態を維持したまま再開できます。
 ゲームをアップデートした際は `python -m monster_rpg.database_setup` を再実行するか、コード内で `database_setup.initialize_database()` を呼び出すことで、HP/MP列や `exploration_progress` テーブルなどの新しいデータが既存のセーブに追加されます。
 
 ## モンスター画像

--- a/backend/src/monster_rpg/database_setup.py
+++ b/backend/src/monster_rpg/database_setup.py
@@ -1,8 +1,9 @@
 # database_setup.py (新規作成)
+import os
 import sqlite3
 import hashlib
 
-DATABASE_NAME = "monster_rpg_save.db"
+DATABASE_NAME = os.getenv("MONSTER_RPG_DB", "monster_rpg_save.db")
 
 
 def _hash_password(password: str) -> str:


### PR DESCRIPTION
## Summary
- read `MONSTER_RPG_DB` env variable in `database_setup.py`
- document the variable in README_EN and README_JA
- mention the override in root README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68535cfdb0a483218dd47cc082587054