### PR TITLE
Add basic trading system

### DIFF
--- a/backend/src/monster_rpg/database_setup.py
+++ b/backend/src/monster_rpg/database_setup.py
@@ -108,6 +108,26 @@ def initialize_database():
 
     cursor.execute(
         """
+        CREATE TABLE IF NOT EXISTS market_listings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            seller_id INTEGER,
+            item_type TEXT,
+            item_id TEXT,
+            price INTEGER,
+            monster_level INTEGER,
+            monster_exp INTEGER,
+            monster_hp INTEGER,
+            monster_max_hp INTEGER,
+            monster_mp INTEGER,
+            monster_max_mp INTEGER,
+            is_sold INTEGER DEFAULT 0,
+            buyer_id INTEGER
+        )
+        """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS monster_book_status (
             player_id INTEGER,
             monster_id TEXT,

--- a/backend/src/monster_rpg/trading.py
+++ b/backend/src/monster_rpg/trading.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import List, Dict, Any
+
+from . import database_setup
+from .player import Player
+from .items.item_data import ALL_ITEMS
+from .monsters.monster_data import ALL_MONSTERS
+from .monsters.monster_class import Monster
+
+DATABASE = database_setup.DATABASE_NAME
+
+
+def _connect():
+    return sqlite3.connect(DATABASE, timeout=5)
+
+
+def list_item(player: Player, item_idx: int, price: int) -> bool:
+    """List an item from the player's inventory for sale."""
+    if not (0 <= item_idx < len(player.items)) or price < 0:
+        return False
+    item = player.items.pop(item_idx)
+    item_id = getattr(item, "item_id", "")
+    with _connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO market_listings (seller_id, item_type, item_id, price)
+            VALUES (?, 'item', ?, ?)
+            """,
+            (player.user_id, item_id, price),
+        )
+        conn.commit()
+    return True
+
+
+def list_monster_from_reserve(player: Player, reserve_idx: int, price: int) -> bool:
+    """List a monster from the player's reserve for sale."""
+    if not (0 <= reserve_idx < len(player.reserve_monsters)) or price < 0:
+        return False
+    mon = player.reserve_monsters.pop(reserve_idx)
+    with _connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO market_listings (
+                seller_id, item_type, item_id, price,
+                monster_level, monster_exp, monster_hp, monster_max_hp,
+                monster_mp, monster_max_mp
+            ) VALUES (?, 'monster', ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                player.user_id,
+                mon.monster_id,
+                price,
+                mon.level,
+                mon.exp,
+                mon.hp,
+                mon.max_hp,
+                mon.mp,
+                mon.max_mp,
+            ),
+        )
+        conn.commit()
+    return True
+
+
+def get_listings() -> List[Dict[str, Any]]:
+    """Return all unsold listings."""
+    with _connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, seller_id, item_type, item_id, price, monster_level,"
+            " monster_exp, monster_hp, monster_max_hp, monster_mp, monster_max_mp"
+            " FROM market_listings WHERE is_sold=0"
+        )
+        rows = cur.fetchall()
+    listings = []
+    for row in rows:
+        (
+            lid,
+            seller_id,
+            item_type,
+            item_id,
+            price,
+            m_level,
+            m_exp,
+            m_hp,
+            m_max_hp,
+            m_mp,
+            m_max_mp,
+        ) = row
+        listings.append(
+            {
+                "id": lid,
+                "seller_id": seller_id,
+                "item_type": item_type,
+                "item_id": item_id,
+                "price": price,
+                "monster_level": m_level,
+                "monster_exp": m_exp,
+                "monster_hp": m_hp,
+                "monster_max_hp": m_max_hp,
+                "monster_mp": m_mp,
+                "monster_max_mp": m_max_mp,
+            }
+        )
+    return listings
+
+
+def buy_listing(player: Player, listing_id: int) -> bool:
+    """Purchase the given listing for the player."""
+    with _connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT seller_id, item_type, item_id, price, monster_level,"
+            " monster_exp, monster_hp, monster_max_hp, monster_mp, monster_max_mp, is_sold"
+            " FROM market_listings WHERE id=?",
+            (listing_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return False
+        (
+            seller_id,
+            item_type,
+            item_id,
+            price,
+            m_level,
+            m_exp,
+            m_hp,
+            m_max_hp,
+            m_mp,
+            m_max_mp,
+            is_sold,
+        ) = row
+        if is_sold or player.gold < price:
+            return False
+        # deduct gold and add to seller
+        cur.execute(
+            "UPDATE player_data SET gold = gold + ? WHERE user_id=?",
+            (price, seller_id),
+        )
+        player.gold -= price
+        if item_type == "item":
+            if item_id in ALL_ITEMS:
+                player.items.append(ALL_ITEMS[item_id])
+        else:
+            if item_id in ALL_MONSTERS:
+                mon = ALL_MONSTERS[item_id].copy()
+                while mon.level < m_level:
+                    mon.gain_exp(mon.calculate_exp_to_next_level())
+                mon.exp = m_exp
+                mon.hp = m_hp if m_hp is not None else mon.max_hp
+                mon.max_hp = m_max_hp if m_max_hp is not None else mon.max_hp
+                mon.mp = m_mp if m_mp is not None else mon.max_mp
+                mon.max_mp = m_max_mp if m_max_mp is not None else mon.max_mp
+                player.party_monsters.append(mon)
+        cur.execute(
+            "UPDATE market_listings SET is_sold=1, buyer_id=? WHERE id=?",
+            (player.user_id, listing_id),
+        )
+        conn.commit()
+    return True

--- a/backend/src/monster_rpg/web/__init__.py
+++ b/backend/src/monster_rpg/web/__init__.py
@@ -19,6 +19,7 @@ def create_app():
     from .inventory import inventory_bp
     from .explore import explore_bp
     from .battle import battle_bp
+    from .market import market_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
@@ -26,6 +27,7 @@ def create_app():
     app.register_blueprint(inventory_bp)
     app.register_blueprint(explore_bp)
     app.register_blueprint(battle_bp)
+    app.register_blueprint(market_bp)
 
     # Backwards compatible endpoint aliases
     alias_map = {

--- a/backend/src/monster_rpg/web/market.py
+++ b/backend/src/monster_rpg/web/market.py
@@ -1,0 +1,58 @@
+from flask import Blueprint, jsonify, request
+
+from .. import database_setup
+from ..player import Player
+from ..trading import list_item, list_monster_from_reserve, get_listings, buy_listing
+
+market_bp = Blueprint('market', __name__)
+
+
+@market_bp.route('/market/listings')
+def listings():
+    return jsonify(get_listings())
+
+
+@market_bp.route('/market/list_item/<int:user_id>', methods=['POST'])
+def list_item_route(user_id):
+    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    if not player:
+        return jsonify({'error': 'player not found'}), 404
+    if not request.is_json:
+        return jsonify({'error': 'json required'}), 400
+    data = request.get_json(silent=True) or {}
+    idx = int(data.get('item_idx', -1))
+    price = int(data.get('price', -1))
+    success = list_item(player, idx, price)
+    if success:
+        player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        return jsonify({'success': True})
+    return jsonify({'success': False}), 400
+
+
+@market_bp.route('/market/list_monster/<int:user_id>', methods=['POST'])
+def list_monster_route(user_id):
+    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    if not player:
+        return jsonify({'error': 'player not found'}), 404
+    if not request.is_json:
+        return jsonify({'error': 'json required'}), 400
+    data = request.get_json(silent=True) or {}
+    idx = int(data.get('reserve_idx', -1))
+    price = int(data.get('price', -1))
+    success = list_monster_from_reserve(player, idx, price)
+    if success:
+        player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        return jsonify({'success': True})
+    return jsonify({'success': False}), 400
+
+
+@market_bp.route('/market/buy/<int:user_id>/<int:listing_id>', methods=['POST'])
+def buy_route(user_id, listing_id):
+    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    if not player:
+        return jsonify({'error': 'player not found'}), 404
+    success = buy_listing(player, listing_id)
+    if success:
+        player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        return jsonify({'success': True})
+    return jsonify({'success': False}), 400

--- a/backend/tests/test_trade.py
+++ b/backend/tests/test_trade.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+
+from monster_rpg import database_setup
+from monster_rpg.web_main import app
+from monster_rpg.player import Player
+from monster_rpg.items.item_data import ALL_ITEMS
+from monster_rpg.monsters.monster_data import ALL_MONSTERS
+
+class TradeTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_trade.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.seller_id = database_setup.create_user('seller', 'pw1')
+        self.buyer_id = database_setup.create_user('buyer', 'pw2')
+        self.client = app.test_client()
+
+        seller = Player('Seller', user_id=self.seller_id)
+        seller.items.append(ALL_ITEMS['small_potion'])
+        seller.add_monster_to_party('slime')
+        seller.add_monster_to_party('goblin')
+        seller.move_to_reserve(0)
+        mon = seller.reserve_monsters[0]
+        mon.gain_exp(mon.calculate_exp_to_next_level())
+        seller.save_game(self.db_path, user_id=self.seller_id)
+
+        buyer = Player('Buyer', user_id=self.buyer_id, gold=200)
+        buyer.add_monster_to_party('goblin')
+        buyer.save_game(self.db_path, user_id=self.buyer_id)
+
+    def tearDown(self):
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_trade_flow(self):
+        resp = self.client.post(f'/market/list_item/{self.seller_id}', json={'item_idx': 0, 'price': 30})
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.post(f'/market/list_monster/{self.seller_id}', json={'reserve_idx': 0, 'price': 80})
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get('/market/listings')
+        data = resp.get_json()
+        self.assertEqual(len(data), 2)
+        item_listing = next(l for l in data if l['item_type'] == 'item')
+        monster_listing = next(l for l in data if l['item_type'] == 'monster')
+
+        resp = self.client.post(f'/market/buy/{self.buyer_id}/{item_listing["id"]}')
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.post(f'/market/buy/{self.buyer_id}/{monster_listing["id"]}')
+        self.assertEqual(resp.status_code, 200)
+
+        buyer = Player.load_game(self.db_path, user_id=self.buyer_id)
+        self.assertEqual(len(buyer.items), 1)
+        self.assertEqual(buyer.items[0].item_id, 'small_potion')
+        self.assertTrue(any(m.monster_id == 'slime' for m in buyer.party_monsters))
+        slime = next(m for m in buyer.party_monsters if m.monster_id == 'slime')
+        self.assertGreaterEqual(slime.level, 2)


### PR DESCRIPTION
## Summary
- create new `market_listings` table in database
- implement `trading.py` module for listing and buying items or monsters
- expose REST endpoints via new `market` blueprint
- register blueprint in web app
- add unit test covering trade flow

## Testing
- `pip install -q Flask networkx matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536bd975808321b7ac48ed6562fa69