### PR TITLE
Add battle JSON endpoint and JS initialization

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -244,4 +244,16 @@ function showDamageIndicator(container, text) {
     setTimeout(() => popup.remove(), 800);
 }
 
-document.addEventListener('DOMContentLoaded', setupBattleUI);
+document.addEventListener('DOMContentLoaded', () => {
+    setupBattleUI();
+    const form = document.querySelector('.command-window form');
+    if (form) {
+        const m = form.action.match(/\/battle\/(\d+)/);
+        if (m) {
+            fetch(`/battle-json/${m[1]}`)
+                .then(resp => resp.json())
+                .then(data => applyBattleData(data))
+                .catch(err => console.error('Fetch error', err));
+        }
+    }
+});

--- a/backend/tests/test_web_battle_get_json.py
+++ b/backend/tests/test_web_battle_get_json.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from monster_rpg import database_setup
+from monster_rpg.web_main import app, Battle, active_battles
+from monster_rpg.player import Player
+from monster_rpg.monsters.monster_class import Monster
+
+class BattleGetJsonTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_web.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.user_id = database_setup.create_user('tester', 'pw')
+        self.client = app.test_client()
+        player = Player('Tester', user_id=self.user_id)
+        hero = Monster('Hero', hp=20, attack=5, defense=2)
+        player.party_monsters.append(hero)
+        enemy = Monster('Slime', hp=10, attack=3, defense=1)
+        battle_obj = Battle(player.party_monsters, [enemy], player)
+        active_battles[self.user_id] = battle_obj
+
+    def tearDown(self):
+        active_battles.pop(self.user_id, None)
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_get_returns_json(self):
+        resp = self.client.get(f'/battle-json/{self.user_id}')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIsInstance(data, dict)
+        self.assertIn('hp_values', data)
+        self.assertIn('log', data)
+        self.assertIn('finished', data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/battle-json/<user_id>` endpoint to expose battle state in JSON
- fetch initial battle info from this new endpoint on page load
- test new GET endpoint for JSON response

## Testing
- `pip install -q Flask networkx matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685378391d00832182328acccdba9329