### PR TITLE
Add Tailwind build docs

### DIFF
--- a/backend/README/README_EN.md
+++ b/backend/README/README_EN.md
@@ -114,6 +114,13 @@ existing save files.
 Place monster pictures under `src/monster_rpg/static/images/` on your local machine. The folder is kept in the repository via an empty `.gitkeep` file but ignored by Git so large image files do not get uploaded.
 The game does **not** include any monster artwork. You must supply PNG files whose names match the `image_filename` entries in `monsters/monster_data.py`. Example files are `slime.png` and `wolf.png`.
 
+## Building Tailwind CSS
+Run the Tailwind CLI whenever you modify `tailwind_src.css` to regenerate the compiled stylesheet:
+
+```bash
+npx tailwindcss -i src/monster_rpg/static/tailwind_src.css -o src/monster_rpg/static/tailwind.css
+```
+
 ## Testing
 Install the package in editable mode before running the test suite:
 

--- a/backend/README/README_JA.md
+++ b/backend/README/README_JA.md
@@ -100,6 +100,13 @@ docker-compose up
 モンスターの画像はローカルの `src/monster_rpg/static/images/` 以下に配置してください。リポジトリには空の `.gitkeep` ファイルのみ含め、大きな画像ファイルはGitにアップロードされないようにしています。
 本プロジェクトにはモンスターの画像素材は付属していません。`monsters/monster_data.py` の `image_filename` に合わせ、`slime.png` や `wolf.png` などの名前で画像ファイルを用意してください。
 
+## Tailwind CSS のビルド
+`tailwind_src.css` を編集したら、次のコマンドでコンパイル済みスタイルシートを更新します:
+
+```bash
+npx tailwindcss -i src/monster_rpg/static/tailwind_src.css -o src/monster_rpg/static/tailwind.css
+```
+
 ## テスト
 `pytest` を実行する前に、パッケージを編集可能モードでインストールしてください:
 

--- a/backend/src/monster_rpg/static/tailwind_src.css
+++ b/backend/src/monster_rpg/static/tailwind_src.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Custom button style */
+.btn-primary {
+  @apply bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./backend/src/monster_rpg/templates/**/*.html", "./backend/src/monster_rpg/static/**/*.js"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- document how to build Tailwind CSS
- provide Japanese docs for the same
- add `tailwind_src.css` and a basic `tailwind.config.js`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68537b1356ec8321ae1a8696d5ab54b2