### PR TITLE
Add JSON POST support for battle actions

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -97,7 +97,13 @@ function setupBattleUI() {
             const postUrl = form.action;  // use the form's action URL
             const submitBtn = form.querySelector('button[type="submit"]');
             if (submitBtn) submitBtn.disabled = true;
-            fetch(postUrl, { method: 'POST', body: formData })
+
+            const payload = Object.fromEntries(formData.entries());
+            fetch(postUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
                 .then(resp => resp.json())
                 .then(data => {
                     if (data.finished) {

--- a/backend/src/monster_rpg/web/battle.py
+++ b/backend/src/monster_rpg/web/battle.py
@@ -200,7 +200,9 @@ def battle(user_id):
             return redirect(url_for('auth.index'))
     if not battle_obj:
         if request.method == 'POST':
-            if request.form.get('continue_explore'):
+            data_src = request.get_json(silent=True)
+            data_src = data_src if data_src is not None else request.form
+            if data_src.get('continue_explore'):
                 return redirect(url_for('explore.explore', user_id=user_id), code=307)
             return redirect(url_for('battle.battle', user_id=user_id))
         loc = LOCATIONS.get(player.current_location_id)
@@ -216,9 +218,11 @@ def battle(user_id):
         active_battles[user_id] = battle_obj
         player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
     if request.method == 'POST':
+        data_src = request.get_json(silent=True)
+        data_src = data_src if data_src is not None else request.form
         current_actor = battle_obj.current_actor()
         if current_actor in battle_obj.player_party:
-            act_val = request.form.get('action', 'attack')
+            act_val = data_src.get('action', 'attack')
             if act_val == 'run':
                 action = {'type': 'run'}
             elif act_val.startswith('skill'):
@@ -226,8 +230,8 @@ def battle(user_id):
                     s_idx = int(act_val[5:])
                 except ValueError:
                     s_idx = 0
-                tgt_e = request.form.get('target_enemy', '-1')
-                tgt_a = request.form.get('target_ally', '0')
+                tgt_e = data_src.get('target_enemy', '-1')
+                tgt_a = data_src.get('target_ally', '0')
                 try:
                     tgt_e = int(tgt_e)
                 except ValueError:
@@ -238,14 +242,14 @@ def battle(user_id):
                     tgt_a = 0
                 action = {'type': 'skill', 'skill': s_idx, 'target_enemy': tgt_e, 'target_ally': tgt_a}
             elif act_val == 'scout':
-                tgt = request.form.get('target_enemy', '-1')
+                tgt = data_src.get('target_enemy', '-1')
                 try:
                     tgt = int(tgt)
                 except ValueError:
                     tgt = -1
                 action = {'type': 'scout', 'target_enemy': tgt}
             else:
-                tgt = request.form.get('target_enemy', '-1')
+                tgt = data_src.get('target_enemy', '-1')
                 try:
                     tgt = int(tgt)
                 except ValueError:
@@ -286,7 +290,9 @@ def battle(user_id):
         player.last_battle_log = msgs
         del active_battles[user_id]
         player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
-        if request.form.get('continue_explore'):
+        data_src = request.get_json(silent=True)
+        data_src = data_src if data_src is not None else request.form
+        if data_src.get('continue_explore'):
             return redirect(url_for('explore.explore', user_id=user_id))
         if request.method == 'POST':
             html = render_template('battle.html', messages=msgs, user_id=user_id)

--- a/backend/tests/test_web_battle_json.py
+++ b/backend/tests/test_web_battle_json.py
@@ -36,5 +36,17 @@ class BattleViewJsonTests(unittest.TestCase):
         self.assertIn('log', data)
         self.assertIn('finished', data)
 
+    def test_post_accepts_json_payload(self):
+        resp = self.client.post(
+            f'/battle/{self.user_id}',
+            json={'action': 'attack', 'target_enemy': 0}
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIsInstance(data, dict)
+        self.assertIn('hp_values', data)
+        self.assertIn('log', data)
+        self.assertIn('finished', data)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- send battle actions as JSON from the client
- support JSON payloads in battle POST route
- test JSON POST requests

## Testing
- `cd backend && pip install -q -e . && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537c3f3714832182540be744d98eb9