### PR TITLE
Add titled equipment drops

### DIFF
--- a/backend/src/monster_rpg/battle.py
+++ b/backend/src/monster_rpg/battle.py
@@ -3,7 +3,7 @@ import random
 from typing import cast
 from .player import Player  # Playerクラスは直接使わないが、型ヒントなどで参照される可能性を考慮
 from .monsters import Monster  # Monsterクラスのみ参照
-from .items.equipment import Equipment, EquipmentInstance
+from .items.equipment import Equipment, EquipmentInstance, create_titled_equipment
 from .skills.skills import Skill  # Skillクラスを参照
 from .skills.skill_actions import apply_effects
 # import traceback # デバッグ時に必要なら再度有効化
@@ -354,11 +354,19 @@ def award_experience(alive_party: list[Monster], defeated_enemies: list[Monster]
         if player is not None:
             for item_obj, rate in getattr(enemy, "drop_items", []):
                 if random.random() < rate:
-                    if isinstance(item_obj, (Equipment, EquipmentInstance)):
+                    if isinstance(item_obj, Equipment):
+                        new_equip = create_titled_equipment(item_obj.equip_id)
+                        if new_equip:
+                            player.equipment_inventory.append(new_equip)
+                            print(f"{new_equip.name} を手に入れた！")
+                        else:
+                            print(f"{item_obj.name} を手に入れ損ねた...")
+                    elif isinstance(item_obj, EquipmentInstance):
                         player.equipment_inventory.append(item_obj)
+                        print(f"{item_obj.name} を手に入れた！")
                     else:
                         player.items.append(item_obj)
-                    print(f"{item_obj.name} を手に入れた！")
+                        print(f"{item_obj.name} を手に入れた！")
 
     alive_monsters = [m for m in alive_party if m.is_alive]
     if alive_monsters and total_exp_reward > 0:

--- a/backend/src/monster_rpg/web/battle.py
+++ b/backend/src/monster_rpg/web/battle.py
@@ -2,7 +2,7 @@ import random
 from flask import Blueprint, render_template, redirect, url_for, request, jsonify
 from .. import database_setup
 from ..player import Player
-from ..items.equipment import Equipment, EquipmentInstance
+from ..items.equipment import Equipment, EquipmentInstance, create_titled_equipment
 from ..monsters.monster_class import Monster
 from ..map_data import LOCATIONS
 from ..exploration import generate_enemy_party
@@ -279,11 +279,19 @@ def battle(user_id):
             for enemy in battle_obj.enemy_party:
                 for item_obj, rate in getattr(enemy, 'drop_items', []):
                     if random.random() < rate:
-                        if isinstance(item_obj, (Equipment, EquipmentInstance)):
+                        if isinstance(item_obj, Equipment):
+                            new_equip = create_titled_equipment(item_obj.equip_id)
+                            if new_equip:
+                                player.equipment_inventory.append(new_equip)
+                                msgs.append({'type': 'info', 'message': f'{new_equip.name} を手に入れた！'})
+                            else:
+                                msgs.append({'type': 'info', 'message': f'{item_obj.name} を手に入れ損ねた...'})
+                        elif isinstance(item_obj, EquipmentInstance):
                             player.equipment_inventory.append(item_obj)
+                            msgs.append({'type': 'info', 'message': f'{item_obj.name} を手に入れた！'})
                         else:
                             player.items.append(item_obj)
-                        msgs.append({'type': 'info', 'message': f'{item_obj.name} を手に入れた！'})
+                            msgs.append({'type': 'info', 'message': f'{item_obj.name} を手に入れた！'})
             msgs.append({'type': 'info', 'message': f'勝利した！ {gold_gain}G を得た。'})
         else:
             msgs.append({'type': 'info', 'message': '敗北してしまった...'})

--- a/backend/tests/test_equipment_drop.py
+++ b/backend/tests/test_equipment_drop.py
@@ -2,7 +2,7 @@ import random
 import unittest
 
 from monster_rpg.battle import award_experience
-from monster_rpg.items.equipment import ALL_EQUIPMENT
+from monster_rpg.items.equipment import ALL_EQUIPMENT, EquipmentInstance
 from monster_rpg.monsters.monster_class import Monster
 from monster_rpg.player import Player
 
@@ -17,7 +17,11 @@ class EquipmentDropTests(unittest.TestCase):
         random.seed(0)
         award_experience([ally], [enemy], player)
         self.assertEqual(len(player.equipment_inventory), 1)
-        self.assertEqual(player.equipment_inventory[0].equip_id, 'bronze_sword')
+        equip = player.equipment_inventory[0]
+        self.assertIsInstance(equip, EquipmentInstance)
+        self.assertEqual(equip.base_item.equip_id, 'bronze_sword')
+        self.assertIsNotNone(equip.title)
+        self.assertEqual(equip.title.title_id, 'glass_cannon')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create titled equipment when items drop in `battle.award_experience`
- apply same titled drop logic in `web.battle`
- update equipment drop test for titled equipment generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853956203508321bc1262cad7fd465b