### PR TITLE
Implement drag-and-drop formation screen

### DIFF
--- a/backend/src/monster_rpg/static/party/formation.css
+++ b/backend/src/monster_rpg/static/party/formation.css
@@ -1,0 +1,121 @@
+/* Formation page styles */
+body {
+    /* wood desk texture background */
+    background-color: #6f4f28;
+    background-image: linear-gradient(45deg, rgba(0,0,0,0.2) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.2) 75%),
+                      linear-gradient(45deg, rgba(0,0,0,0.2) 25%, transparent 25%, transparent 75%, rgba(0,0,0,0.2) 75%);
+    background-size: 60px 60px;
+    background-position: 0 0, 30px 30px;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    color: #3c2f2f;
+    line-height: 1.7;
+    margin: 0;
+    padding: 20px;
+    -webkit-user-select: none;
+    user-select: none;
+}
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+}
+header {
+    text-align: center;
+    margin-bottom: 40px;
+    color: #fff;
+}
+header h1 {
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    font-size: 3.2em;
+    font-weight: bold;
+    font-style: italic;
+    color: #f0e68c;
+    text-shadow: 3px 3px 5px rgba(0,0,0,0.7);
+}
+.book-page {
+    background-color: #faf0e6;
+    border: 1px solid #c8b496;
+    padding: 25px;
+    box-shadow: 0px 0px 2px rgba(0,0,0,0.3),
+                -3px 3px 3px rgba(0,0,0,0.2),
+                -6px 6px 4px rgba(0,0,0,0.1),
+                -9px 9px 5px rgba(0,0,0,0.05);
+    margin-bottom: 25px;
+    border-radius: 2px 5px 5px 2px;
+    position: relative;
+}
+.book-page h2 {
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    font-size: 1.8em;
+    color: #5d4037;
+    border-bottom: 1px solid #dcdcdc;
+    padding-bottom: 10px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    font-weight: bold;
+    font-style: italic;
+}
+.main-grid {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 30px;
+}
+.ornate-button {
+    display: block;
+    width: 100%;
+    background-color: #8c7853;
+    border: 1px solid #5d4037;
+    border-radius: 3px;
+    padding: 10px 15px;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    font-weight: bold;
+    color: #fff;
+    cursor: pointer;
+    text-align: center;
+    font-size: 1.1em;
+    margin-bottom: 15px;
+    box-shadow: inset 0 0 2px rgba(255,255,255,0.4), 2px 2px 3px rgba(0,0,0,0.4);
+    transition: all 0.2s;
+}
+.ornate-button:hover { background-color: #a28d6a; }
+.ornate-button:active { box-shadow: inset 2px 2px 3px rgba(0,0,0,0.4); transform: translateY(1px); }
+.team-slots, .monster-grid { display: grid; gap: 15px; }
+.team-slots { grid-template-columns: repeat(3, 1fr); }
+.monster-grid { grid-template-columns: repeat(auto-fill, minmax(90px, 1fr)); }
+.drop-area {
+    background-color: #f5eadd;
+    border: 1px solid #dcdcdc;
+    background-image: radial-gradient(#d2b48c 1px, transparent 1px);
+    background-size: 10px 10px;
+    min-height: 140px;
+    padding: 5px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: #888;
+    transition: all 0.3s ease;
+}
+.monster-item { cursor: grab; transition: all 0.2s ease; max-width: 100%; position: relative; }
+.monster-item img {
+    display: block;
+    width: 100%;
+    border: 4px solid #bda072;
+    border-radius: 3px;
+    box-shadow: 2px 2px 5px rgba(0,0,0,0.3);
+    pointer-events: none;
+}
+.monster-item.dragging { opacity: 0.5; transform: rotate(-5deg) scale(0.9); cursor: grabbing; }
+.drop-area.drag-over { background-color: #fdf5e6; border-color: #bda072; box-shadow: inset 0 0 15px #bda072; }
+.monster-placeholder { width: 100%; height: 100%; display:flex; align-items:center; justify-content:center; font-style: italic; }
+footer {
+    margin-top: 40px;
+    text-align: center;
+    font-size: 0.9em;
+    color: #e0e0e0;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+}
+@media (max-width: 768px) {
+    .main-grid { grid-template-columns: 1fr; }
+    header h1 { font-size: 2.5em; }
+}

--- a/backend/src/monster_rpg/static/party/formation.js
+++ b/backend/src/monster_rpg/static/party/formation.js
@@ -1,0 +1,107 @@
+window.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('monster-detail-modal');
+    const modalBody = document.getElementById('modal-card-body');
+
+    function displayDetails(data) {
+        modalBody.textContent = '';
+        const imgArea = document.createElement('div');
+        imgArea.className = 'card-image-area';
+        const img = document.createElement('img');
+        img.src = data.image;
+        img.alt = data.name;
+        img.className = 'card-monster-img';
+        imgArea.appendChild(img);
+        modalBody.appendChild(imgArea);
+
+        const header = document.createElement('div');
+        header.className = 'card-header';
+        const h2 = document.createElement('h2');
+        h2.id = 'modal-title';
+        h2.className = 'card-monster-name';
+        h2.textContent = data.name;
+        header.appendChild(h2);
+        const info = document.createElement('div');
+        info.className = 'card-monster-lvhp';
+        info.textContent = `Lv. ${data.level} | HP: ${data.hp} / ${data.max_hp}`;
+        header.appendChild(info);
+        modalBody.appendChild(header);
+
+        const content = document.createElement('div');
+        content.className = 'card-content';
+        const stats = document.createElement('div');
+        stats.className = 'card-stats-grid';
+        ['attack','defense','speed'].forEach(key => {
+            const span = document.createElement('span');
+            span.textContent = `${key}: ${data.stats[key]}`;
+            stats.appendChild(span);
+        });
+        content.appendChild(stats);
+        const descSec = document.createElement('div');
+        descSec.className = 'card-section card-description';
+        const h3 = document.createElement('h3');
+        h3.textContent = '説明';
+        const p = document.createElement('p');
+        p.textContent = data.description;
+        descSec.appendChild(h3);
+        descSec.appendChild(p);
+        content.appendChild(descSec);
+        modalBody.appendChild(content);
+        modal.classList.add('show');
+    }
+
+    function closeModal() { modal.classList.remove('show'); }
+    modal.querySelector('.modal-close-btn').addEventListener('click', closeModal);
+    modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+    modal.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+
+    document.querySelectorAll('.monster-item').forEach(item => {
+        item.addEventListener('click', () => {
+            const data = JSON.parse(item.dataset.details);
+            displayDetails(data);
+        });
+    });
+
+    // drag and drop
+    const dropAreas = document.querySelectorAll('.drop-area');
+    let draggedItem = null;
+
+    document.querySelectorAll('.monster-item').forEach(draggable => {
+        draggable.addEventListener('dragstart', e => {
+            draggedItem = e.target;
+            setTimeout(() => draggedItem.classList.add('dragging'), 0);
+        });
+        draggable.addEventListener('dragend', () => {
+            if (draggedItem) draggedItem.classList.remove('dragging');
+            draggedItem = null;
+        });
+    });
+
+    dropAreas.forEach(area => {
+        area.addEventListener('dragover', e => { e.preventDefault(); area.classList.add('drag-over'); });
+        area.addEventListener('dragleave', () => area.classList.remove('drag-over'));
+        area.addEventListener('drop', e => {
+            e.preventDefault();
+            area.classList.remove('drag-over');
+            if (!draggedItem) return;
+            const existing = area.querySelector('.monster-item');
+            if (existing && existing !== draggedItem) {
+                draggedItem.parentElement.appendChild(existing);
+            }
+            area.appendChild(draggedItem);
+        });
+    });
+
+    const confirmBtn = document.getElementById('confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.addEventListener('click', e => {
+            e.preventDefault();
+            const order = [];
+            document.querySelectorAll('.team-slots .monster-item').forEach(el => order.push(el.dataset.uid));
+            const reserve = [];
+            document.querySelectorAll('#monster-pool .monster-item').forEach(el => reserve.push(el.dataset.uid));
+            document.getElementById('order-input').value = JSON.stringify(order);
+            document.getElementById('reserve-input').value = JSON.stringify(reserve);
+            document.getElementById('formation-form').submit();
+        });
+    }
+});

--- a/backend/src/monster_rpg/templates/formation.html
+++ b/backend/src/monster_rpg/templates/formation.html
@@ -1,276 +1,81 @@
 {% extends "layout.html" %}
+{% block head_extra %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='party/formation.css') }}">
+{% endblock %}
 {% block content %}
-<div class="book-bg">
-  <div class="book-page fade-in">
-    <h2 class="book-title">編成</h2>
-
-    <h3 class="section-title">編集中</h3>
-    <ul class="member-list">
-      {% for m in player.party_monsters %}
-      <li class="member-item">
-        <div class="member-left">
-          <span class="member-index">{{ loop.index }}.</span>
-          {% if m.image_filename %}
-          <img
-            class="monster-img"
-            src="{{ url_for('static', filename='images/' + m.image_filename) }}"
-            alt="{{ m.name }}"
-          >
-          {% endif %}
-          <span class="member-name">{{ m.name }}</span>
-        </div>
-        <div class="member-actions">
-          <form action="{{ url_for('formation', user_id=user_id) }}" method="post" class="action-form">
-            <input type="hidden" name="index" value="{{ loop.index0 }}">
-            {% if not loop.first %}
-            <button type="submit" name="move" value="up" class="arrow-btn">↑</button>
-            {% endif %}
-            {% if not loop.last %}
-            <button type="submit" name="move" value="down" class="arrow-btn">↓</button>
-            {% endif %}
-            <button type="submit" name="remove" value="1" class="remove-btn">外す</button>
-          </form>
-        </div>
-      </li>
-      {% endfor %}
-    </ul>
-
-    <h3 class="section-title">未編成</h3>
-    <ul class="member-list">
-      {% for m in player.reserve_monsters %}
-      <li class="member-item">
-        <form action="{{ url_for('formation', user_id=user_id) }}" method="post" class="action-form">
-          <input type="hidden" name="add_index" value="{{ loop.index0 }}">
-          <button type="submit" class="reserve-btn">
-            {% if m.image_filename %}
-            <img
-              class="monster-img"
-              src="{{ url_for('static', filename='images/' + m.image_filename) }}"
-              alt="{{ m.name }}"
-            >
-            {% endif %}
-            <span class="member-name">{{ m.name }}</span>
-          </button>
+<div class="container">
+  <header>
+    <h1>幻獣の魔導書</h1>
+    <p>汝の最も恐るべき幻獣の部隊を編成せよ。</p>
+  </header>
+  <div class="main-grid">
+    <aside class="sidebar">
+      <div class="book-page">
+        <form id="formation-form" method="post" action="{{ url_for('formation', user_id=user_id) }}">
+          <input type="hidden" name="order" id="order-input">
+          <input type="hidden" name="reserve" id="reserve-input">
+          <button id="confirm-btn" type="button" class="ornate-button">編成を確定</button>
+          <button type="submit" name="reset" value="1" class="ornate-button">再編成</button>
         </form>
-      </li>
-      {% endfor %}
-    </ul>
-
-    <form action="{{ url_for('formation', user_id=user_id) }}" method="post" class="reset-form">
-      <button type="submit" name="reset" value="1" class="reset-btn">リセット</button>
-    </form>
-
-    <a class="book-link" href="{{ url_for('party', user_id=user_id) }}">← 戻る</a>
+        <h2 style="margin-top: 20px;">部隊の状態</h2>
+        <div style="font-style: italic; color: #666;">
+          <p>汝の部隊の総合力がここに表示されるであろう。</p>
+        </div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <section class="book-page">
+        <h2>召喚陣 (汝の部隊)</h2>
+        <div class="team-slots">
+          {% for entry in party_info %}
+          <div id="slot-{{ loop.index }}" class="drop-area" data-slot="true">
+            <div class="monster-item" data-uid="{{ entry.uid }}" data-details='{{ entry.detail | tojson | forceescape }}' draggable="true">
+              {% if entry.monster.image_filename %}
+              <img src="{{ url_for('static', filename='images/' + entry.monster.image_filename) }}" alt="{{ entry.monster.name }}">
+              {% else %}
+              {{ entry.monster.name }}
+              {% endif %}
+            </div>
+          </div>
+          {% endfor %}
+          {% for i in range(party_info|length + 1, 4) %}
+          <div id="slot-{{ i }}" class="drop-area" data-slot="true">
+            <div class="monster-placeholder">スロット {{ i }}</div>
+          </div>
+          {% endfor %}
+        </div>
+      </section>
+      <section class="book-page">
+        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px;">
+          <h2>待機中の幻獣 (ストック)</h2>
+        </div>
+        <div id="monster-pool" class="drop-area">
+          <div class="monster-grid">
+            {% for entry in reserve_info %}
+            <div id="monster-{{ entry.uid }}" class="monster-item" data-uid="{{ entry.uid }}" data-details='{{ entry.detail | tojson | forceescape }}' draggable="true">
+              {% if entry.monster.image_filename %}
+              <img alt="{{ entry.monster.name }}" src="{{ url_for('static', filename='images/' + entry.monster.image_filename) }}">
+              {% else %}
+              <span class="monster-placeholder">{{ entry.monster.name }}</span>
+              {% endif %}
+            </div>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <footer>
+    <p>© 2023 幻獣の魔導書. All rights reserved.</p>
+  </footer>
+</div>
+<div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+  <div class="modal-card">
+    <button class="modal-close-btn" aria-label="閉じる">&times;</button>
+    <div id="modal-card-body"></div>
   </div>
 </div>
-
-<style>
-  body {
-    background: #f9eee0;
-    min-height: 100vh;
-  }
-  .book-bg {
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    min-height: 100vh;
-    padding-top: 48px;
-  }
-  .book-page {
-    background: #f7f2e6;
-    border: 4px solid #b68b4c;
-    border-radius: 18px;
-    max-width: 460px;
-    width: 96%;
-    box-shadow:
-      0 4px 32px #7b51120a,
-      0 0 0 10px #e6d3b6;
-    padding: 32px 24px 38px 24px;
-    position: relative;
-  }
-  .book-title {
-    font-family: 'Georgia', 'Times New Roman', serif;
-    text-align: center;
-    font-size: 2rem;
-    margin-bottom: 1em;
-    color: #895c1a;
-    letter-spacing: 2px;
-    text-shadow: 0 2px 1px #f4e3bd, 0 0 6px #f4e3bd88;
-    border-bottom: 2px solid #b68b4c55;
-    padding-bottom: 0.2em;
-  }
-  .section-title {
-    font-family: 'Georgia', serif;
-    font-size: 1.3rem;
-    color: #6c4a1b;
-    margin-top: 1.4em;
-    margin-bottom: 0.6em;
-    letter-spacing: 1px;
-    border-left: 4px solid #b68b4c;
-    padding-left: 8px;
-  }
-  .member-list {
-    list-style: none;
-    padding: 0;
-    margin: 0 0 1.2em 0;
-  }
-  .member-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: linear-gradient(90deg, #f6e9d1 80%, #e6d3b6 100%);
-    border-radius: 8px;
-    box-shadow: 0 1px 5px #c1b28b33 inset;
-    border-left: 5px solid #b68b4cbb;
-    margin-bottom: 0.8em;
-    padding: 8px 12px 8px 10px;
-    position: relative;
-    transition: box-shadow 0.3s ease, border-color 0.3s ease;
-  }
-  .member-item.magic-hover {
-    box-shadow: 0 0 22px 3px #ffc85788, 0 0 0 6px #e0c38a22 inset;
-    border-color: #c39b3d;
-  }
-  .member-left {
-    display: flex;
-    align-items: center;
-    gap: 0.8em;
-  }
-  .member-index {
-    font-family: 'Georgia', serif;
-    font-size: 1.05rem;
-    color: #7c5e2a;
-  }
-  .monster-img {
-    width: 52px;
-    height: 52px;
-    object-fit: contain;
-    border-radius: 6px;
-    background: #e3dac0;
-    border: 2px solid #c9b383;
-    box-shadow: 0 2px 4px #b68b4c1a;
-  }
-  .member-name {
-    font-family: 'Georgia', serif;
-    font-size: 1.08rem;
-    color: #5d4b29;
-    letter-spacing: 1px;
-  }
-  .member-actions .action-form {
-    display: flex;
-    gap: 0.3em;
-  }
-  .arrow-btn {
-    background: #8c6d3b;
-    color: #f7efe2;
-    border: none;
-    border-radius: 4px;
-    font-size: 0.95rem;
-    width: 32px;
-    height: 28px;
-    cursor: pointer;
-    box-shadow: 0 2px 6px #5a3e22;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-  }
-  .arrow-btn:hover {
-    background: #b68b4c;
-    box-shadow: 0 3px 8px #7b5112;
-  }
-  .remove-btn {
-    background: #ab2a2a;
-    color: #fffbe6;
-    border: none;
-    border-radius: 4px;
-    font-size: 0.9rem;
-    padding: 4px 8px;
-    cursor: pointer;
-    box-shadow: 0 2px 6px #7b3e3e;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-  }
-  .remove-btn:hover {
-    background: #c03939;
-    box-shadow: 0 3px 8px #8b2b2b;
-  }
-  .reserve-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.6em;
-    background: #f2f0e5;
-    border: none;
-    border-radius: 6px;
-    padding: 6px 10px;
-    cursor: pointer;
-    font-family: 'Georgia', serif;
-    font-size: 1rem;
-    color: #5d4b29;
-    box-shadow: 0 1px 4px #b5a47d22;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-  }
-  .reserve-btn:hover {
-    background: #e6d3b6;
-    box-shadow: 0 2px 6px #b68b4c33;
-  }
-  .reset-form {
-    text-align: center;
-    margin-top: 1em;
-  }
-  .reset-btn {
-    background: #75562e;
-    color: #f7efe2;
-    border: none;
-    border-radius: 6px;
-    font-size: 1rem;
-    padding: 6px 20px;
-    cursor: pointer;
-    box-shadow: 0 2px 6px #55401f;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-  }
-  .reset-btn:hover {
-    background: #a17c4b;
-    box-shadow: 0 3px 8px #7b5112;
-  }
-  .book-link {
-    display: block;
-    margin: 1.2em auto 0 auto;
-    color: #9c7228;
-    font-family: 'Georgia', serif;
-    font-size: 1rem;
-    text-decoration: underline wavy #b68b4c66;
-    letter-spacing: 1px;
-    padding-top: 8px;
-    text-align: center;
-    transition: color 0.2s ease;
-  }
-  .book-link:hover {
-    color: #ad8236;
-    text-decoration: underline wavy #a17c4b;
-  }
-
-  /* ふわっと現れる */
-  .fade-in {
-    opacity: 0;
-    transform: translateY(32px) scale(0.98);
-    transition: 0.9s cubic-bezier(0.19, 1, 0.22, 1);
-  }
-  .fade-in.show {
-    opacity: 1;
-    transform: none;
-  }
-</style>
-
-<script>
-  // ページ開いたらふわっと出現
-  window.addEventListener('DOMContentLoaded', function() {
-    document.querySelector('.fade-in').classList.add('show');
-    // 編集中リストにマウスオーバーで魔法の光演出
-    document.querySelectorAll('.member-item').forEach(function(el) {
-      el.addEventListener('mouseenter', function() {
-        el.classList.add('magic-hover');
-      });
-      el.addEventListener('mouseleave', function() {
-        el.classList.remove('magic-hover');
-      });
-    });
-  });
-</script>
+{% endblock %}
+{% block scripts %}
+  <script src="{{ url_for('static', filename='party/formation.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- overhaul formation HTML and add new grimoire-style layout
- add JS for drag/drop behaviour and monster detail modal
- add matching stylesheet
- update backend route to save new party order

## Testing
- `pip install -e backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b4f508f48321a9294a1995fac758