### PR TITLE
Ensure monster detail modal grabs focus

### DIFF
--- a/backend/src/monster_rpg/static/party/formation.js
+++ b/backend/src/monster_rpg/static/party/formation.js
@@ -47,6 +47,7 @@ window.addEventListener('DOMContentLoaded', () => {
         content.appendChild(descSec);
         modalBody.appendChild(content);
         modal.classList.add('show');
+        modal.focus();
     }
 
     function closeModal() { modal.classList.remove('show'); }

--- a/backend/src/monster_rpg/static/party/party.js
+++ b/backend/src/monster_rpg/static/party/party.js
@@ -176,6 +176,7 @@
       content.appendChild(equipSection);
       modalCardBody.appendChild(content);
       modal.classList.add('show');
+      modal.focus();
       modalCardBody.querySelectorAll('.equip-btn').forEach(btn => {
         btn.addEventListener('click', () => {
           btn.disabled = true;

--- a/backend/src/monster_rpg/templates/formation.html
+++ b/backend/src/monster_rpg/templates/formation.html
@@ -69,7 +69,7 @@
     <p>© 2023 幻獣の魔導書. All rights reserved.</p>
   </footer>
 </div>
-<div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+<div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title" tabindex="-1">
   <div class="modal-card">
     <button class="modal-close-btn" aria-label="閉じる">&times;</button>
     <div id="modal-card-body"></div>

--- a/backend/src/monster_rpg/templates/party.html
+++ b/backend/src/monster_rpg/templates/party.html
@@ -30,7 +30,7 @@
   </div>
 </div>
 
-  <div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+  <div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title" tabindex="-1">
     <div class="modal-card">
       <button class="modal-close-btn" aria-label="閉じる">&times;</button>
       <div id="modal-card-body"></div>


### PR DESCRIPTION
## Summary
- add `tabindex="-1"` to monster detail modal containers
- focus the modal after showing in party and formation JS
- keep Esc to close the modal while tests pass

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853cabf831c8321a8bd4859a242760b