### PR TITLE
Add quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ This repository provides README files in multiple languages:
 
 Set the environment variable `MONSTER_RPG_DB` to change where the game saves
 its SQLite database.
+
+## Quickstart
+Install the package from the `backend` directory and launch the web interface:
+
+```bash
+cd backend
+pip install -e .
+python -m monster_rpg.database_setup
+python -m monster_rpg.start_rpg
+```
+
+The server starts at <http://localhost:5000/> and provides the full game.


### PR DESCRIPTION
## Summary
- document quickstart steps in the root README

## Testing
- `pip install -e ./backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854119a7bc4832182fc92cdc3f3bb1d