### PR TITLE
Fix start page link in result template

### DIFF
--- a/backend/src/monster_rpg/templates/result.html
+++ b/backend/src/monster_rpg/templates/result.html
@@ -4,6 +4,6 @@
 {% if user_id %}
 <a href="{{ url_for('play', user_id=user_id) }}">戻る</a>
 {% else %}
-<a href="{{ url_for('index') }}">トップへ</a>
+<a href="{{ url_for('auth.index') }}">トップへ</a>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- fix landing page link when user creation fails
- run automated tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68541614b1208321a2f837f812d6afa3