### PR TITLE
Fix: add back link on formation page

### DIFF
--- a/backend/src/monster_rpg/static/party/formation.css
+++ b/backend/src/monster_rpg/static/party/formation.css
@@ -115,6 +115,22 @@ footer {
     color: #e0e0e0;
     text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
 }
+.book-link {
+    display: block;
+    margin: 0 auto;
+    color: #9c7228;
+    font-family: 'Georgia', serif;
+    font-size: 1.05em;
+    text-decoration: underline wavy #b68b4c66;
+    letter-spacing: 1.1px;
+    padding-top: 8px;
+    text-align: center;
+    transition: color .17s;
+}
+.book-link:hover {
+    color: #ad8236;
+    text-decoration: underline wavy #a17c4b;
+}
 @media (max-width: 768px) {
     .main-grid { grid-template-columns: 1fr; }
     header h1 { font-size: 2.5em; }

--- a/backend/src/monster_rpg/templates/formation.html
+++ b/backend/src/monster_rpg/templates/formation.html
@@ -65,10 +65,11 @@
       </section>
     </main>
   </div>
-  <footer>
-    <p>© 2023 幻獣の魔導書. All rights reserved.</p>
-  </footer>
-</div>
+    <footer>
+      <p>© 2023 幻獣の魔導書. All rights reserved.</p>
+    </footer>
+    <a class="book-link" href="{{ url_for('party', user_id=user_id) }}">← 戻る</a>
+  </div>
 <div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title" tabindex="-1">
   <div class="modal-card">
     <button class="modal-close-btn" aria-label="閉じる">&times;</button>


### PR DESCRIPTION
## Summary
- enable returning to the party screen from formation
- style the new link in formation page CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx', 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854175bc4308321bcfe2c4a4a0e6b42