### PR TITLE
Remove unused imports and export monsters

### DIFF
--- a/backend/src/monster_rpg/monsters/__init__.py
+++ b/backend/src/monster_rpg/monsters/__init__.py
@@ -15,3 +15,16 @@ from .synthesis_rules import (
 )
 from .evolution_rules import EVOLUTION_RULES
 
+__all__ = [
+    "Monster",
+    "GROWTH_TYPE_AVERAGE",
+    "GROWTH_TYPE_EARLY",
+    "GROWTH_TYPE_LATE",
+    "ALL_MONSTERS",
+    "load_monsters",
+    "SYNTHESIS_RECIPES",
+    "SYNTHESIS_ITEMS_REQUIRED",
+    "MONSTER_ITEM_RECIPES",
+    "EVOLUTION_RULES",
+]
+

--- a/backend/src/monster_rpg/skills/skill_actions.py
+++ b/backend/src/monster_rpg/skills/skill_actions.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Callable, Dict, List
 import random
 
-from .skills import Skill
 from ..monsters.monster_class import Monster
 
 

--- a/backend/src/monster_rpg/trading.py
+++ b/backend/src/monster_rpg/trading.py
@@ -7,7 +7,6 @@ from . import database_setup
 from .player import Player
 from .items.item_data import ALL_ITEMS
 from .monsters.monster_data import ALL_MONSTERS
-from .monsters.monster_class import Monster
 
 DATABASE = database_setup.DATABASE_NAME
 

--- a/backend/src/monster_rpg/web/battle.py
+++ b/backend/src/monster_rpg/web/battle.py
@@ -3,7 +3,6 @@ from flask import Blueprint, render_template, redirect, url_for, request, jsonif
 from .. import database_setup
 from ..player import Player
 from ..items.equipment import Equipment, EquipmentInstance, create_titled_equipment
-from ..monsters.monster_class import Monster
 from ..map_data import LOCATIONS
 from ..exploration import generate_enemy_party
 

--- a/backend/src/monster_rpg/web/utils.py
+++ b/backend/src/monster_rpg/web/utils.py
@@ -1,6 +1,4 @@
 from ..player import Player
-from ..items.equipment import Equipment, EquipmentInstance
-from ..monsters.monster_class import Monster
 
 
 def process_synthesis_payload(player: Player, data: dict):

--- a/backend/src/monster_rpg/web_main.py
+++ b/backend/src/monster_rpg/web_main.py
@@ -7,4 +7,4 @@ from .web.battle import Battle, active_battles
 
 app = create_app()
 
-__all__ = ["app", "Battle", "active_battles"]
+__all__ = ["app", "Battle", "active_battles", "random"]


### PR DESCRIPTION
## Summary
- drop unused imports throughout the web code
- re-export symbols from `monster_rpg.monsters`
- keep `random` import for testing

## Testing
- `ruff check src --select F401`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854dd07fdc88321be2f923b76f811be