### PR TITLE
Add skill set system

### DIFF
--- a/backend/src/monster_rpg/monsters/monster_loader.py
+++ b/backend/src/monster_rpg/monsters/monster_loader.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple
 
 from .monster_class import Monster, GROWTH_TYPE_AVERAGE, RANK_D
 from ..skills.skills import ALL_SKILLS
+from ..skills.skill_sets import ALL_SKILL_SETS
 from ..items.item_data import ALL_ITEMS
 from ..items.equipment import ALL_EQUIPMENT
 from .monster_data import MonsterBookEntry
@@ -46,7 +47,25 @@ def load_monsters(filepath: str | None = None) -> Tuple[Dict[str, Monster], Dict
             image_filename=attrs.get("image_filename"),
         )
         # skills
-        skills = [ALL_SKILLS[s] for s in attrs.get("skills", []) if s in ALL_SKILLS]
+        skill_ids = list(attrs.get("skills", []))
+        # include skills from referenced sets
+        for set_id in attrs.get("skill_sets", []):
+            sset = ALL_SKILL_SETS.get(set_id)
+            if not sset:
+                continue
+            for lvl, ids in sset.get("learnset", {}).items():
+                if lvl <= m.level:
+                    if isinstance(ids, str):
+                        ids = [ids]
+                    for sid in ids:
+                        if sid not in skill_ids:
+                            skill_ids.append(sid)
+        # additional skills
+        for sid in attrs.get("additional_skills", []):
+            if sid not in skill_ids:
+                skill_ids.append(sid)
+
+        skills = [ALL_SKILLS[s] for s in skill_ids if s in ALL_SKILLS]
         m.skills = skills
         # drop items
         drops = []
@@ -56,7 +75,25 @@ def load_monsters(filepath: str | None = None) -> Tuple[Dict[str, Monster], Dict
                 drops.append((item, rate))
         m.drop_items = drops
         # learnset
-        learnset = attrs.get("learnset", {})
+        learnset = attrs.get("learnset", {}).copy()
+        for set_id in attrs.get("skill_sets", []):
+            sset = ALL_SKILL_SETS.get(set_id)
+            if not sset:
+                continue
+            for lvl, ids in sset.get("learnset", {}).items():
+                key = str(lvl)
+                existing = learnset.get(key)
+                if existing is None:
+                    learnset[key] = ids
+                    continue
+                if isinstance(existing, str):
+                    existing = [existing]
+                if isinstance(ids, str):
+                    ids = [ids]
+                for sid in ids:
+                    if sid not in existing:
+                        existing.append(sid)
+                learnset[key] = existing
         m.learnset = {int(k): v for k, v in learnset.items()}
 
         monsters[monster_id] = m

--- a/backend/src/monster_rpg/monsters/monsters.json
+++ b/backend/src/monster_rpg/monsters/monsters.json
@@ -6,7 +6,7 @@
     "element": "水",
     "image_filename": "slime.png",
     "stats": { "hp": 25, "mp": 0, "attack": 8, "defense": 5, "speed": 5 },
-    "skills": ["heal"],
+    "skill_sets": ["starter_slime"],
     "drop_items": [
       ["small_potion", 0.5]
     ],
@@ -24,7 +24,7 @@
     "element": "無",
     "image_filename": "goblin.png",
     "stats": { "hp": 40, "mp": 0, "attack": 12, "defense": 8, "speed": 7 },
-    "skills": ["fireball"],
+    "skill_sets": ["starter_goblin"],
     "drop_items": [
       ["small_potion", 0.2],
       ["magic_stone", 0.1],
@@ -66,7 +66,7 @@
     "element": "無",
     "image_filename": "wolf.png",
     "stats": { "hp": 50, "mp": 0, "attack": 15, "defense": 7, "speed": 10 },
-    "skills": [],
+    "skill_sets": ["starter_wolf"],
     "drop_items": [
       ["medium_potion", 0.1]
     ],

--- a/backend/src/monster_rpg/skills/__init__.py
+++ b/backend/src/monster_rpg/skills/__init__.py
@@ -1,0 +1,2 @@
+from .skills import ALL_SKILLS, load_skills
+from .skill_sets import ALL_SKILL_SETS, load_skill_sets

--- a/backend/src/monster_rpg/skills/skill_sets.json
+++ b/backend/src/monster_rpg/skills/skill_sets.json
@@ -1,0 +1,22 @@
+{
+  "starter_slime": {
+    "name": "スライム基礎",
+    "learnset": {
+      "1": ["heal"],
+      "2": ["guard_up"]
+    }
+  },
+  "starter_goblin": {
+    "name": "ゴブリン基礎",
+    "learnset": {
+      "1": ["fireball"],
+      "3": ["power_up"]
+    }
+  },
+  "starter_wolf": {
+    "name": "ウルフ基礎",
+    "learnset": {
+      "4": ["speed_up"]
+    }
+  }
+}

--- a/backend/src/monster_rpg/skills/skill_sets.py
+++ b/backend/src/monster_rpg/skills/skill_sets.py
@@ -1,0 +1,34 @@
+"""Skill set loader module."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Any
+
+
+def load_skill_sets(filepath: str | None = None) -> Dict[str, Dict[str, Any]]:
+    """Load skill set data from JSON file."""
+    if filepath is None:
+        filepath = os.path.join(os.path.dirname(__file__), "skill_sets.json")
+
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError as e:
+        raise ValueError(f"Skill set data file not found: {filepath}") from e
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid skill set JSON in {filepath}") from e
+
+    sets: Dict[str, Dict[str, Any]] = {}
+    for set_id, attrs in data.items():
+        learnset = attrs.get("learnset", {})
+        sets[set_id] = {
+            "name": attrs.get("name", set_id),
+            "learnset": {int(k): v for k, v in learnset.items()},
+        }
+    return sets
+
+
+# Load default skill sets on import
+ALL_SKILL_SETS: Dict[str, Dict[str, Any]] = load_skill_sets()

--- a/backend/tests/test_monster_loader.py
+++ b/backend/tests/test_monster_loader.py
@@ -17,6 +17,23 @@ class MonsterLoaderTests(unittest.TestCase):
         self.assertEqual(monsters['slime'].name, 'スライム')
         self.assertEqual(monsters['goblin'].rank, RANK_D)
 
+    def test_skill_sets_provide_skills_and_learnset(self):
+        monsters, _ = load_monsters()
+        goblin = monsters['goblin']
+        # starting skills from skill set
+        skill_names = [s.name for s in goblin.skills]
+        self.assertIn('ファイアボール', skill_names)
+
+        # copy to level up
+        g = goblin.copy()
+        # gain enough exp to reach level 3
+        for _ in range(2):
+            exp_needed = g.calculate_exp_to_next_level()
+            g.gain_exp(exp_needed)
+
+        learned_names = [s.name for s in g.skills]
+        self.assertIn('パワーアップ', learned_names)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- define reusable skill collections in `skill_sets.json`
- load skill sets via new `skill_sets.py`
- merge skill sets in `monster_loader` and `monster_data`
- reference starter skill sets in `monsters.json`
- ensure loader provides skills from sets
- test skill set behavior

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f1ee0af4832195350607f0bbddf0