### PR TITLE
Update skill set docs

### DIFF
--- a/backend/README/README_EN.md
+++ b/backend/README/README_EN.md
@@ -62,6 +62,36 @@ Use `monster_loader.load_monsters()` to read monster definitions from `monsters/
 - `skills/skills.py` &mdash; defines the `Skill` class and loads definitions from `skills/skills.json`. The dictionary `ALL_SKILLS` stores all available skills.
 - `items/item_data.py` &mdash; defines the `Item` class and loads data from `items/items.json` as `ALL_ITEMS`.
 - `skills/__init__.py` &mdash; an empty module used to mark the directory as a package.
+- `skills/skill_sets.py` &mdash; loads reusable skill packages defined in `skills/skill_sets.json`.
+
+#### Skill Sets
+`skill_sets.json` groups common learnsets that multiple monsters can reference. Each entry is keyed by an identifier and contains a display `name` and a `learnset` dictionary mapping a level to one or more skill IDs.
+
+```json
+{
+  "starter_slime": {
+    "name": "Slime Basics",
+    "learnset": {
+      "1": ["heal"],
+      "2": ["guard_up"]
+    }
+  }
+}
+```
+
+Monsters may include a `skill_sets` array and an optional `additional_skills` list inside `monsters.json`. Learnsets from these sets are merged with the monster's own `learnset`.
+
+```json
+{
+  "slime": {
+    "skill_sets": ["starter_slime"],
+    "additional_skills": ["tackle"],
+    "learnset": { "5": ["water_blast"] }
+  }
+}
+```
+
+In this example the Slime will start with the skills from the `starter_slime` set plus `tackle`, and will learn both the set's moves and `water_blast` as it levels.
 
 ### Maps
 - `map_data.py` &mdash; defines the `Location` class and the dictionary `LOCATIONS` which describes available areas and how they connect. `STARTING_LOCATION_ID` indicates where the player begins. Locations can include an `enemy_pool` dict for weighted encounters, a `party_size` range for the number of enemies, and an optional `required_item` field to lock certain areas until the player has that item.

--- a/backend/README/README_JA.md
+++ b/backend/README/README_JA.md
@@ -58,6 +58,36 @@ docker-compose up
 - `skills/skills.py` — `Skill` クラスを定義し、`skills/skills.json` からスキル情報を読み込みます。辞書 `ALL_SKILLS` に利用可能なスキルを格納します。
 - `items/item_data.py` — `Item` クラスを定義し、`items/items.json` を読み込んで `ALL_ITEMS` を生成します。
 - `skills/__init__.py` — ディレクトリをパッケージとして扱うための空モジュールです。
+- `skills/skill_sets.py` — `skills/skill_sets.json` に定義された再利用可能なスキルセットを読み込みます。
+
+#### スキルセット
+`skill_sets.json` では、複数のモンスターで共有できる習得データをまとめて管理します。各エントリは識別子をキーとし、表示用の `name` と、レベルをキーにスキルIDを列挙した `learnset` を持ちます。
+
+```json
+{
+  "starter_slime": {
+    "name": "スライム基礎",
+    "learnset": {
+      "1": ["heal"],
+      "2": ["guard_up"]
+    }
+  }
+}
+```
+
+`monsters.json` では `skill_sets` 配列と任意の `additional_skills` リストを指定できます。これらのセットに含まれる習得スキルは、モンスター自身の `learnset` と結合されます。
+
+```json
+{
+  "slime": {
+    "skill_sets": ["starter_slime"],
+    "additional_skills": ["tackle"],
+    "learnset": { "5": ["water_blast"] }
+  }
+}
+```
+
+この例ではスライムは `starter_slime` セットのスキルに加え、`tackle` を初期習得し、レベルアップ時にはセットの習得表と `water_blast` の両方を学びます。
 
 ### マップ
 - `map_data.py` — `Location` クラスと、各エリアの接続関係を示す辞書 `LOCATIONS` を定義します。 `STARTING_LOCATION_ID` がプレイヤーの初期位置です。各場所では、出現モンスターとその重みを設定する `enemy_pool` と、敵の数範囲を指定する `party_size` を利用できます。さらに、特定のアイテムが必要なエリアには `required_item` を設定できます。


### PR DESCRIPTION
## Summary
- document `skill_sets.json` and how to reference it from monsters
- provide English and Japanese examples

## Testing
- `pip install -e backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f7eec0bc832180e2bb212c2de224