### PR TITLE
Implement skill damage scaling

### DIFF
--- a/backend/src/monster_rpg/battle.py
+++ b/backend/src/monster_rpg/battle.py
@@ -188,7 +188,7 @@ def apply_skill_effect(
             continue
 
         if skill_obj.effects:
-            apply_effects(caster, target, skill_obj.effects)
+            apply_effects(caster, target, skill_obj.effects, skill_obj)
         else:
             print(f"スキル「{skill_obj.name}」は効果がなかった...")
 

--- a/backend/src/monster_rpg/items/item_effects.py
+++ b/backend/src/monster_rpg/items/item_effects.py
@@ -26,5 +26,5 @@ def apply_item_effect(item: Item, target: Optional[Monster]) -> bool:
         print("対象モンスターがいません。")
         return False
     for eff in effects:
-        apply_effects(target, target, [eff])
+        apply_effects(target, target, [eff], None)
     return True

--- a/backend/tests/test_skill_actions.py
+++ b/backend/tests/test_skill_actions.py
@@ -9,7 +9,7 @@ class SkillActionIntegrationTests(unittest.TestCase):
     def test_status_mapping_poison(self):
         target = Monster('Target', hp=20, attack=5, defense=2)
         skill = Skill('Poison', power=0, skill_type='status', effects=[{'type': 'status', 'status': 'poison'}])
-        apply_effects(target, target, skill.effects)
+        apply_effects(target, target, skill.effects, skill)
         self.assertTrue(any(e['name'] == 'poison' for e in target.status_effects))
 
     def test_brave_song_uses_buff_function(self):
@@ -20,6 +20,27 @@ class SkillActionIntegrationTests(unittest.TestCase):
         apply_skill_effect(m1, [m1], skill, all_allies=allies)
         self.assertEqual(m1.attack, 15)
         self.assertEqual(m2.attack, 17)
+
+    def test_damage_scaling_uses_correct_stats(self):
+        warrior = Monster('Warrior', hp=30, attack=20, defense=5)
+        warrior.magic = 5
+        mage = Monster('Mage', hp=30, attack=5, defense=5)
+        mage.magic = 20
+        target1 = Monster('Target1', hp=50, attack=5, defense=5)
+        target2 = Monster('Target2', hp=50, attack=5, defense=5)
+
+        phys_skill = Skill('Slash', power=10, skill_type='attack', effects=[{'type': 'damage'}], category='物理')
+        mag_skill = Skill('Bolt', power=10, skill_type='attack', effects=[{'type': 'damage'}], category='魔法')
+
+        apply_skill_effect(warrior, [target1], phys_skill)
+        apply_skill_effect(mage, [target2], phys_skill)
+        self.assertGreater(target2.hp, target1.hp)
+
+        target3 = Monster('Target3', hp=50, attack=5, defense=5)
+        target4 = Monster('Target4', hp=50, attack=5, defense=5)
+        apply_skill_effect(warrior, [target3], mag_skill)
+        apply_skill_effect(mage, [target4], mag_skill)
+        self.assertGreater(target3.hp, target4.hp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add elemental multipliers and damage scaling for skills
- update battle and item modules for new apply_effects signature
- extend tests for skill damage scaling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685500fbb5188321b6c7fc6e45d1d6d1