### PR TITLE
Add taunt and cant_attack statuses

### DIFF
--- a/backend/tests/test_new_statuses.py
+++ b/backend/tests/test_new_statuses.py
@@ -1,0 +1,27 @@
+import pytest
+from monster_rpg.battle import enemy_take_action
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.skills.skills import ALL_SKILLS
+
+
+def test_taunt_forces_attack(monkeypatch):
+    hero = Monster('Hero', hp=40, attack=5, defense=2)
+    enemy = Monster('Enemy', hp=30, attack=10, defense=5, skills=[ALL_SKILLS['heal']], ai_role='healer')
+    enemy.apply_status('taunt', 1)
+    players = [hero]
+    enemies = [enemy]
+    monkeypatch.setattr('random.random', lambda: 0.0)
+    monkeypatch.setattr('random.choice', lambda seq: seq[0])
+    enemy_take_action(enemy, players, enemies)
+    assert hero.hp < 40
+
+
+def test_cant_attack_prevents_attack(monkeypatch):
+    hero = Monster('Hero', hp=40, attack=5, defense=2)
+    enemy = Monster('Goblin', hp=30, attack=8, defense=3, ai_role='attacker')
+    enemy.apply_status('cant_attack', 1)
+    players = [hero]
+    enemies = [enemy]
+    monkeypatch.setattr('random.random', lambda: 1.0)
+    enemy_take_action(enemy, players, enemies)
+    assert hero.hp == 40

--- a/backend/tests/test_status_effects.py
+++ b/backend/tests/test_status_effects.py
@@ -67,6 +67,8 @@ class StatusEffectTests(unittest.TestCase):
             "stun",
             "sleep",
             "confuse",
+            "taunt",
+            "cant_attack",
         ]
         for status in statuses:
             target = Monster("T", hp=20, attack=5, defense=2, speed=10)


### PR DESCRIPTION
## Summary
- add `taunt` and `cant_attack` status effects
- return detailed flags from `process_status_effects`
- update battle logic to respect new statuses
- test that statuses expire and influence enemy behaviour

## Testing
- `cd backend && make test`

------
https://chatgpt.com/codex/tasks/task_e_68550b9462088321b6bff475225c581e