### PR TITLE
Implement percentage buff handling

### DIFF
--- a/backend/src/monster_rpg/monsters/monster_class.py
+++ b/backend/src/monster_rpg/monsters/monster_class.py
@@ -242,6 +242,27 @@ class Monster:
                 'remove_func': revert,
             })
 
+    def apply_buff_percent(self, stat: str, percent_amount: float, duration: int) -> None:
+        """Apply a percentage based buff to the given stat."""
+        if not hasattr(self, stat):
+            return
+
+        base_value = getattr(self, stat)
+        bonus_amount = int(base_value * percent_amount)
+        setattr(self, stat, base_value + bonus_amount)
+        print(f"✨ {self.name} の {stat} が {bonus_amount} 上昇した！")
+
+        def revert_buff(monster_instance: "Monster" = self, stat_name: str = stat, applied_bonus: int = bonus_amount) -> None:
+            current_value = getattr(monster_instance, stat_name)
+            setattr(monster_instance, stat_name, current_value - applied_bonus)
+
+        if duration > 0:
+            self.status_effects.append({
+                'name': f'buff_percent_{stat}',
+                'remaining': duration,
+                'remove_func': revert_buff,
+            })
+
     def apply_status(self, name: str, duration: int | None = None) -> None:
         from ..battle import apply_status
         apply_status(self, name, duration)

--- a/backend/src/monster_rpg/skills/skill_actions.py
+++ b/backend/src/monster_rpg/skills/skill_actions.py
@@ -71,6 +71,15 @@ def _handle_buff(caster: Monster, target: Monster, effect: dict, skill: Optional
         target.apply_buff(stat, amount, duration)
 
 
+def _handle_buff_percent(caster: Monster, target: Monster, effect: dict, skill: Optional[Skill] = None) -> None:
+    """Handle percentage-based buff effects."""
+    stat = effect.get("stat")
+    amount = float(effect.get("amount", 0.0))
+    duration = int(effect.get("duration", getattr(skill, "duration", 0)))
+    if stat:
+        target.apply_buff_percent(stat, amount, duration)
+
+
 def _handle_status(caster: Monster, target: Monster, effect: dict, skill: Optional[Skill] = None) -> None:
     status = effect.get("status")
     duration = effect.get("duration")
@@ -110,6 +119,7 @@ HANDLERS: Dict[str, Callable[[Monster, Monster, dict, Optional[Skill]], None]] =
     "damage": _handle_damage,
     "heal": _handle_heal,
     "buff": _handle_buff,
+    "buff_percent": _handle_buff_percent,
     "status": _handle_status,
     "revive": _handle_revive,
     "cure_status": _handle_cure_status,

--- a/backend/src/monster_rpg/skills/skills.json
+++ b/backend/src/monster_rpg/skills/skills.json
@@ -414,5 +414,16 @@
     "effects": [{"type": "buff", "stat": "defense", "amount": -5, "duration": 3}],
     "description": "敵の防御力を下げる",
     "category": "弱体"
+  },
+  "demonize": {
+    "name": "鬼神化",
+    "power": 0,
+    "cost": 18,
+    "skill_type": "buff",
+    "category": "補助",
+    "description": "3ターンの間、自身の肉体を限界以上に活性化させ、攻撃力を50%上昇させる。",
+    "effects": [
+      { "type": "buff_percent", "stat": "attack", "amount": 0.50, "duration": 3 }
+    ]
   }
 }

--- a/backend/tests/test_party_buff.py
+++ b/backend/tests/test_party_buff.py
@@ -20,5 +20,14 @@ class PartyBuffTests(unittest.TestCase):
         self.assertEqual(m1.attack, 10)
         self.assertEqual(m2.attack, 12)
 
+    def test_demonize_percent_buff(self):
+        monster = Monster('Hero', hp=40, attack=20, defense=10)
+        skill = ALL_SKILLS['demonize']
+        apply_skill_effect(monster, [monster], skill)
+        self.assertEqual(monster.attack, 30)
+        for _ in range(skill.effects[0]['duration']):
+            process_status_effects(monster)
+        self.assertEqual(monster.attack, 20)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support percent-based buff skills
- add `demonize` skill example
- test new percent buff logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550bc4c6a88321bebf7d3d22824335