### PR TITLE
Implement charge skill mechanism

### DIFF
--- a/backend/src/monster_rpg/skills/skill_actions.py
+++ b/backend/src/monster_rpg/skills/skill_actions.py
@@ -106,6 +106,15 @@ def _handle_cure_status(caster: Monster, target: Monster, effect: dict, skill: O
         target.cure_status(status)
 
 
+def _handle_charge(caster: Monster, target: Monster, effect: dict, skill: Optional[Skill] = None) -> None:
+    """Apply a charging state that will trigger another skill next turn."""
+    release_id = effect.get("release_skill_id")
+    duration = int(effect.get("duration", 2))
+    target.apply_status("charging", duration)
+    if target.status_effects and target.status_effects[-1]["name"] == "charging":
+        target.status_effects[-1]["release_skill_id"] = release_id
+
+
 HANDLERS: Dict[str, Callable[[Monster, Monster, dict, Optional[Skill]], None]] = {
     "damage": _handle_damage,
     "heal": _handle_heal,
@@ -113,6 +122,7 @@ HANDLERS: Dict[str, Callable[[Monster, Monster, dict, Optional[Skill]], None]] =
     "status": _handle_status,
     "revive": _handle_revive,
     "cure_status": _handle_cure_status,
+    "charge": _handle_charge,
 }
 
 

--- a/backend/tests/test_charge_release.py
+++ b/backend/tests/test_charge_release.py
@@ -1,0 +1,24 @@
+import unittest
+
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.battle import apply_skill_effect, process_status_effects, process_charge_state
+from monster_rpg.skills.skills import Skill
+
+class ChargeReleaseTests(unittest.TestCase):
+    def test_charge_to_release_flow(self):
+        attacker = Monster('Hero', hp=30, attack=10, defense=5)
+        enemy = Monster('Slime', hp=30, attack=5, defense=2)
+        original_def = attacker.defense
+        charge_skill = Skill('Charge', power=0, skill_type='status',
+                             effects=[{'type': 'charge', 'release_skill_id': 'tackle'}])
+        apply_skill_effect(attacker, [attacker], charge_skill)
+        self.assertTrue(any(e['name'] == 'charging' for e in attacker.status_effects))
+        process_status_effects(attacker)
+        triggered = process_charge_state(attacker, [attacker], [enemy])
+        self.assertTrue(triggered)
+        self.assertFalse(any(e['name'] == 'charging' for e in attacker.status_effects))
+        self.assertEqual(attacker.defense, original_def)
+        self.assertEqual(enemy.hp, enemy.max_hp - 23)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support `charge` skill effect with automatic release next turn
- track charged status in battle loop
- include defense debuff during charge
- test charge to release flow

## Testing
- `pip install Flask networkx matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550d511e048321a6f37cad7a3345ca