### PR TITLE
Implement hp cost effects and new skills

### DIFF
--- a/backend/src/monster_rpg/skills/skills.json
+++ b/backend/src/monster_rpg/skills/skills.json
@@ -414,5 +414,29 @@
     "effects": [{"type": "buff", "stat": "defense", "amount": -5, "duration": 3}],
     "description": "敵の防御力を下げる",
     "category": "弱体"
+  },
+  "blood_saber": {
+    "name": "ブラッドセイバー",
+    "power": 60,
+    "cost": 0,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "hp_cost_percent", "percent": 0.1},
+      {"type": "damage"}
+    ],
+    "description": "HPを10%消費して強烈な斬撃を放つ",
+    "category": "物理"
+  },
+  "last_wish": {
+    "name": "ラストウィッシュ",
+    "power": 80,
+    "cost": 0,
+    "skill_type": "attack",
+    "effects": [
+      {"type": "self_ko"},
+      {"type": "damage", "amount": 80}
+    ],
+    "description": "自らを犠牲に大ダメージを与える",
+    "category": "物理"
   }
 }

--- a/backend/tests/test_skill_actions.py
+++ b/backend/tests/test_skill_actions.py
@@ -42,6 +42,30 @@ class SkillActionIntegrationTests(unittest.TestCase):
         apply_skill_effect(mage, [target4], mag_skill)
         self.assertGreater(target3.hp, target4.hp)
 
+    def test_hp_cost_percent_handler(self):
+        m = Monster('Hero', hp=50, attack=10, defense=5)
+        ctx = apply_effects(m, m, [{'type': 'hp_cost_percent', 'percent': 0.2}])
+        self.assertEqual(m.hp, 40)
+        self.assertIn('last_hp_cost', ctx)
+        self.assertEqual(ctx['last_hp_cost'], 10)
+
+    def test_blood_saber_skill(self):
+        hero = Monster('Hero', hp=50, attack=15, defense=5)
+        enemy = Monster('Enemy', hp=40, attack=5, defense=2)
+        skill = ALL_SKILLS['blood_saber']
+        apply_skill_effect(hero, [enemy], skill)
+        self.assertEqual(hero.hp, 45)
+        self.assertLess(enemy.hp, 40)
+
+    def test_last_wish_skill(self):
+        hero = Monster('Hero', hp=30, attack=15, defense=5)
+        enemy = Monster('Enemy', hp=40, attack=5, defense=2)
+        skill = ALL_SKILLS['last_wish']
+        apply_skill_effect(hero, [enemy], skill)
+        self.assertFalse(hero.is_alive)
+        self.assertEqual(hero.hp, 0)
+        self.assertLess(enemy.hp, 40)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend skill handler system with context support
- add handlers for HP percentage cost and self KO
- register new `blood_saber` and `last_wish` skills
- test new skill behaviour

## Testing
- `pip install -q Flask networkx matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550f43ad28832180f490e9e3689329