### PR TITLE
Add percent-based buff support

### DIFF
--- a/backend/src/monster_rpg/monsters/monster_class.py
+++ b/backend/src/monster_rpg/monsters/monster_class.py
@@ -242,6 +242,22 @@ class Monster:
                 'remove_func': revert,
             })
 
+    def apply_buff_percent(self, stat: str, percent_amount: float, duration: int) -> None:
+        if not stat:
+            return
+        bonus = int(getattr(self, stat) * percent_amount)
+        setattr(self, stat, getattr(self, stat) + bonus)
+
+        def revert(m: "Monster" = self, s: str = stat, b: int = bonus) -> None:
+            setattr(m, s, getattr(m, s) - b)
+
+        if duration > 0:
+            self.status_effects.append({
+                'name': f'buff_percent_{stat}',
+                'remaining': duration,
+                'remove_func': revert,
+            })
+
     def apply_status(self, name: str, duration: int | None = None) -> None:
         from ..battle import apply_status
         apply_status(self, name, duration)

--- a/backend/src/monster_rpg/skills/skill_actions.py
+++ b/backend/src/monster_rpg/skills/skill_actions.py
@@ -93,6 +93,20 @@ def _handle_buff(
         target.apply_buff(stat, amount, duration)
 
 
+def _handle_buff_percent(
+    caster: Monster,
+    target: Monster,
+    effect: dict,
+    skill: Optional[Skill] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> None:
+    stat = effect.get("stat")
+    amount = float(effect.get("amount", 0))
+    duration = int(effect.get("duration", 0))
+    if stat:
+        target.apply_buff_percent(stat, amount, duration)
+
+
 def _handle_status(
     caster: Monster,
     target: Monster,
@@ -200,6 +214,7 @@ HANDLERS: Dict[str, Callable[[Monster, Monster, dict, Optional[Skill], Optional[
     "damage": _handle_damage,
     "heal": _handle_heal,
     "buff": _handle_buff,
+    "buff_percent": _handle_buff_percent,
     "status": _handle_status,
     "revive": _handle_revive,
     "cure_status": _handle_cure_status,

--- a/backend/src/monster_rpg/skills/skills.json
+++ b/backend/src/monster_rpg/skills/skills.json
@@ -427,6 +427,19 @@
     "description": "HPを10%消費して強烈な斬撃を放つ",
     "category": "物理"
   },
+  "demonize": {
+    "name": "デモナイズ",
+    "power": 0,
+    "cost": 4,
+    "skill_type": "buff",
+    "target": "ally",
+    "duration": 3,
+    "effects": [
+      {"type": "buff_percent", "stat": "attack", "amount": 0.5, "duration": 3}
+    ],
+    "description": "味方の攻撃力を50%高める",
+    "category": "補助"
+  },
   "last_wish": {
     "name": "ラストウィッシュ",
     "power": 80,

--- a/backend/tests/test_buff_percent.py
+++ b/backend/tests/test_buff_percent.py
@@ -1,0 +1,30 @@
+import unittest
+
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.battle import apply_skill_effect, process_status_effects
+from monster_rpg.skills.skills import ALL_SKILLS
+
+
+class BuffPercentTests(unittest.TestCase):
+    def test_apply_buff_percent(self):
+        m = Monster('Hero', hp=30, attack=10, defense=5)
+        m.apply_buff_percent('attack', 0.5, 2)
+        self.assertEqual(m.attack, 15)
+        self.assertTrue(any(e['name'] == 'buff_percent_attack' for e in m.status_effects))
+        for _ in range(2):
+            process_status_effects(m)
+        self.assertEqual(m.attack, 10)
+        self.assertFalse(m.status_effects)
+
+    def test_demonize_skill(self):
+        m = Monster('Hero', hp=30, attack=10, defense=5)
+        skill = ALL_SKILLS['demonize']
+        apply_skill_effect(m, [m], skill)
+        self.assertEqual(m.attack, 15)
+        for _ in range(skill.duration):
+            process_status_effects(m)
+        self.assertEqual(m.attack, 10)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support new buff percent status effect on monsters
- handle `buff_percent` effects in skill actions
- add `demonize` skill demonstrating percent buff
- test percentage buff logic

## Testing
- `PYTHONPATH=backend/src pytest backend/tests/test_buff_percent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685510f853b08321a0492dff7726f44a