### PR TITLE
Remove unused map visualizers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,1 @@
 Flask
-networkx
-matplotlib

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -17,8 +17,6 @@ setup(
         ]
     },
     install_requires=[
-        'Flask',
-        'networkx',
-        'matplotlib'
+        'Flask'
     ],
 )

--- a/backend/src/monster_rpg/map_data.py
+++ b/backend/src/monster_rpg/map_data.py
@@ -4,8 +4,6 @@ import os
 import random  # エンカウント判定で使います
 import copy
 from typing import Optional
-import networkx as nx
-import matplotlib.pyplot as plt
 from .monsters import Monster, ALL_MONSTERS
 
 
@@ -210,41 +208,3 @@ def get_map_grid() -> list[list[Location | None]]:
     return grid
 
 
-def display_map() -> None:
-    """ワールドマップを表示する"""
-    print("===== ワールドマップ =====")
-    print(get_map_overview())
-    print("========================")
-
-
-def display_map_graph(save_path: Optional[str] = None) -> None:
-    """ネットワーク図としてマップを描画する
-
-    Parameters
-    ----------
-    save_path: Optional[str]
-        画像を保存するファイルパス。指定しない場合は画面に表示する。
-    """
-    if not LOCATIONS:
-        return
-
-    graph = nx.DiGraph()
-    labels = {}
-    for loc_id, loc in LOCATIONS.items():
-        graph.add_node(loc_id)
-        labels[loc_id] = loc.name
-        for dest_id in loc.connections.values():
-            graph.add_edge(loc_id, dest_id)
-
-    pos = nx.spring_layout(graph, seed=42)
-    plt.figure(figsize=(8, 6))
-    nx.draw_networkx_nodes(graph, pos, node_color="#A0CBE2")
-    nx.draw_networkx_labels(graph, pos, labels, font_size=8)
-    nx.draw_networkx_edges(graph, pos, arrows=True, arrowstyle="->")
-    plt.axis("off")
-
-    if save_path:
-        plt.savefig(save_path, bbox_inches="tight")
-        plt.close()
-    else:
-        plt.show()


### PR DESCRIPTION
## Summary
- prune unused display functions from `map_data`
- drop `networkx` and `matplotlib` dependencies

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855411dadf483219ef69d8106a54b73