### PR TITLE
Remove unused random import

### DIFF
--- a/backend/src/monster_rpg/web_main.py
+++ b/backend/src/monster_rpg/web_main.py
@@ -1,7 +1,5 @@
 """Web entry point for the Monster RPG game."""
 
-import random
-
 from .web import create_app
 from .web.battle import Battle, active_battles
 

--- a/backend/tests/test_hidden_connections.py
+++ b/backend/tests/test_hidden_connections.py
@@ -28,8 +28,8 @@ class HiddenConnectionsTests(unittest.TestCase):
     def test_connections_unlocked_at_100(self):
         loc = LOCATIONS['deep_forest']
         self.assertNotIn('さらに奥へ', loc.connections)
-        with patch('monster_rpg.web_main.random.randint', return_value=20), \
-             patch('monster_rpg.web_main.random.random', return_value=1.0):
+        with patch('monster_rpg.web.explore.random.randint', return_value=20), \
+             patch('monster_rpg.web.explore.random.random', return_value=1.0):
             self.client.post(f'/explore/{self.user_id}')
         self.assertIn('さらに奥へ', loc.connections)
 


### PR DESCRIPTION
## Summary
- remove `random` import from web entry point
- patch the test to stub out the random module where it is used

## Testing
- `pip install -e backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554428b0bc832195934235869983b4