### PR TITLE
Fix battle turn script URL handling

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -94,7 +94,7 @@ function setupBattleUI() {
         form.addEventListener('submit', evt => {
             evt.preventDefault();
             const formData = new FormData(form);
-            const postUrl = form.action;  // use the form's action URL
+            const postUrl = form.getAttribute('action');  // use the form's action URL
             const submitBtn = form.querySelector('button[type="submit"]');
             if (submitBtn) submitBtn.disabled = true;
 
@@ -254,9 +254,9 @@ document.addEventListener('DOMContentLoaded', () => {
     setupBattleUI();
     const form = document.querySelector('.command-window form');
     if (form) {
-        const m = form.action.match(/\/battle\/(\d+)/);
+        const m = form.getAttribute('action').match(/\/battle\/(\d+)/);
         if (m) {
-            fetch(`/battle-json/${m[1]}`)
+            fetch(`/battle/${m[1]}`)
                 .then(resp => resp.json())
                 .then(data => applyBattleData(data))
                 .catch(err => console.error('Fetch error', err));


### PR DESCRIPTION
## Summary
- fix command submission to use `form.getAttribute('action')`
- update initial JSON fetch to parse action via `getAttribute` and request `/battle/<id>`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554d0f54c88321b858674709f4d07f