### PR TITLE
Disable auto-scroll for battle window

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -125,7 +125,8 @@ function setupBattleUI() {
     }
 
     const cmdWindow = document.querySelector('.command-window');
-    if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
+    // Disabled auto scrolling to keep the battle screen position
+    // if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
 }
 
 function updateUnitList(units, infoList) {
@@ -232,7 +233,8 @@ function applyBattleData(data) {
     }
 
     const cmdWindow = document.querySelector('.command-window');
-    if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
+    // Disabled auto scrolling to keep the battle screen position
+    // if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
 }
 
 function showDamageIndicator(container, text) {


### PR DESCRIPTION
## Summary
- comment out scrollIntoView calls in the battle turn script

## Testing
- `pip install Flask`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6855542bec4c83219da7973fba124aae