### PR TITLE
Show equipment stats in party view

### DIFF
--- a/backend/src/monster_rpg/static/party/party.js
+++ b/backend/src/monster_rpg/static/party/party.js
@@ -193,6 +193,9 @@
               equipmentList.length = 0;
               resp.equipment_inventory.forEach(e => equipmentList.push(e));
               data.equipment = resp.monster_equipment;
+              if (resp.monster_stats) {
+                data.stats = resp.monster_stats;
+              }
               displayMonsterDetails(data);
             }
           })
@@ -218,6 +221,9 @@
               equipmentList.length = 0;
               resp.equipment_inventory.forEach(e => equipmentList.push(e));
               data.equipment = resp.monster_equipment;
+              if (resp.monster_stats) {
+                data.stats = resp.monster_stats;
+              }
               displayMonsterDetails(data);
             }
           })

--- a/backend/src/monster_rpg/web/party.py
+++ b/backend/src/monster_rpg/web/party.py
@@ -25,7 +25,11 @@ def party(user_id):
                 'exp': m.exp,
                 'exp_to_next': m.calculate_exp_to_next_level(),
                 'image': url_for('static', filename='images/' + m.image_filename) if m.image_filename else '',
-                'stats': {'attack': m.attack, 'defense': m.defense, 'speed': m.speed},
+                'stats': {
+                    'attack': m.total_attack(),
+                    'defense': m.total_defense(),
+                    'speed': m.total_speed(),
+                },
                 'skills': m.get_skill_details(),
                 'description': MONSTER_BOOK_DATA.get(m.monster_id).description if MONSTER_BOOK_DATA.get(m.monster_id) else 'このモンスターに関する詳しい説明はまだ見つかっていない。',
                 'index': idx,
@@ -78,7 +82,17 @@ def equip(user_id):
         for e in player.equipment_inventory
     ]
     monster_equipment = {slot: eq.name for slot, eq in monster.equipment.items()}
-    return jsonify({'success': success, 'equipment_inventory': equipment_inventory, 'monster_equipment': monster_equipment})
+    monster_stats = {
+        'attack': monster.total_attack(),
+        'defense': monster.total_defense(),
+        'speed': monster.total_speed(),
+    }
+    return jsonify({
+        'success': success,
+        'equipment_inventory': equipment_inventory,
+        'monster_equipment': monster_equipment,
+        'monster_stats': monster_stats,
+    })
 
 @party_bp.route('/formation/<int:user_id>', methods=['GET', 'POST'], endpoint='formation')
 def formation(user_id):
@@ -121,7 +135,11 @@ def formation(user_id):
             'exp': m.exp,
             'exp_to_next': m.calculate_exp_to_next_level(),
             'image': url_for('static', filename='images/' + m.image_filename) if m.image_filename else '',
-            'stats': {'attack': m.attack, 'defense': m.defense, 'speed': m.speed},
+            'stats': {
+                'attack': m.total_attack(),
+                'defense': m.total_defense(),
+                'speed': m.total_speed(),
+            },
             'skills': m.get_skill_details(),
             'description': MONSTER_BOOK_DATA.get(m.monster_id).description if MONSTER_BOOK_DATA.get(m.monster_id) else 'このモンスターに関する詳しい説明はまだ見つかっていない。'
         }


### PR DESCRIPTION
## Summary
- display attack/defense/speed with equipment bonuses on the party and formation pages
- update equip API to return updated stats
- refresh monster details with new stats after equipping/unequipping

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685572d2ce8883219aab0196436f5a94