### PR TITLE
Update learnsets and remove compatibility hooks

### DIFF
--- a/backend/src/monster_rpg/monsters/monster_data.py
+++ b/backend/src/monster_rpg/monsters/monster_data.py
@@ -125,15 +125,6 @@ def load_monsters(filepath: str | None = None) -> Tuple[Dict[str, Monster], Dict
 # Load monster data at import time
 ALL_MONSTERS, MONSTER_BOOK_DATA = _load_from_json()
 
-# Additional learnsets applied to loaded monsters for compatibility
-_LEARNSETS = {
-    "slime": {2: ["guard_up"]},
-    "goblin": {3: ["power_up"]},
-    "wolf": {4: ["speed_up"]},
-}
-for mid, ls in _LEARNSETS.items():
-    if mid in ALL_MONSTERS:
-        ALL_MONSTERS[mid].learnset.update(ls)
 
 # Provide direct access to common monsters
 SLIME = ALL_MONSTERS.get("slime")

--- a/backend/src/monster_rpg/monsters/monsters.json
+++ b/backend/src/monster_rpg/monsters/monsters.json
@@ -22,7 +22,11 @@
         0.5
       ]
     ],
-    "learnset": {},
+    "learnset": {
+      "2": [
+        "guard_up"
+      ]
+    },
     "book": {
       "description": "ぷるぷるした弱小モンスター。水属性で、初心者の相手に最適。",
       "location_hint": "村の近くの草原などに出現",
@@ -61,6 +65,9 @@
       ]
     ],
     "learnset": {
+      "3": [
+        "power_up"
+      ],
       "4": [
         "sand_attack"
       ]
@@ -128,7 +135,11 @@
         0.1
       ]
     ],
-    "learnset": {},
+    "learnset": {
+      "4": [
+        "speed_up"
+      ]
+    },
     "book": {
       "description": "俊敏な牙獣。群れで行動することが多い。",
       "location_hint": "妖精の森の奥地や丘陵街道に出現",


### PR DESCRIPTION
## Summary
- move default learnsets into `monsters.json`
- drop compatibility learnset patching logic

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557eec38648321b5505a5cb9772311