### PR TITLE
Refactor player methods into separate managers

### DIFF
--- a/backend/src/monster_rpg/evolution_manager.py
+++ b/backend/src/monster_rpg/evolution_manager.py
@@ -1,0 +1,10 @@
+"""Utilities for monster evolution handling."""
+
+from __future__ import annotations
+
+from .monsters.monster_class import Monster
+
+
+def try_evolution(monster: Monster, verbose: bool = True) -> None:
+    """Trigger the monster's internal evolution check."""
+    monster._try_evolution(verbose=verbose)

--- a/backend/src/monster_rpg/party_manager.py
+++ b/backend/src/monster_rpg/party_manager.py
@@ -1,0 +1,233 @@
+"""Functions for managing player parties and inventories."""
+
+from __future__ import annotations
+
+import copy
+from typing import Optional
+
+from .monsters.monster_class import Monster
+from .monsters.monster_data import ALL_MONSTERS
+from .items.item_data import ALL_ITEMS
+from .items.equipment import (
+    CRAFTING_RECIPES,
+    create_titled_equipment,
+    EquipmentInstance,
+    Equipment,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .player import Player
+
+
+def add_monster_to_party(player: "Player", monster_id_or_object) -> Optional[Monster]:
+    """Add a monster to the player's active party."""
+    newly_added_monster = None
+    if isinstance(monster_id_or_object, str):
+        monster_id_key = monster_id_or_object.lower()
+        if monster_id_key in ALL_MONSTERS:
+            new_monster_instance = ALL_MONSTERS[monster_id_key].copy()
+            if new_monster_instance is None:
+                print(f"エラー: モンスター '{monster_id_key}' のコピーに失敗しました。")
+                return None
+            new_monster_instance.level = 1
+            new_monster_instance.exp = 0
+            new_monster_instance.hp = new_monster_instance.max_hp
+            new_monster_instance.mp = new_monster_instance.max_mp
+            player.party_monsters.append(new_monster_instance)
+            print(f"{new_monster_instance.name} が仲間に加わった！")
+            newly_added_monster = new_monster_instance
+        else:
+            print(f"エラー: モンスターID '{monster_id_key}' は存在しません。")
+    elif isinstance(monster_id_or_object, Monster):
+        monster_object = monster_id_or_object
+        copied_monster = monster_object.copy()
+        if copied_monster is None:
+            print(f"エラー: モンスターオブジェクト '{monster_object.name}' のコピーに失敗しました。")
+            return None
+        player.party_monsters.append(copied_monster)
+        copied_monster.mp = copied_monster.max_mp
+        print(f"{copied_monster.name} が仲間に加わった！")
+        newly_added_monster = copied_monster
+    else:
+        print("エラー: add_monster_to_party の引数が不正です。")
+
+    if newly_added_monster:
+        print(
+            f"[DEBUG add_monster_to_party] Actual monster_id of added monster '{newly_added_monster.name}': '{newly_added_monster.monster_id}' (type: {type(newly_added_monster.monster_id)})"
+        )
+        player.monster_book.record_captured(newly_added_monster.monster_id)
+        return newly_added_monster
+    return None
+
+
+def show_all_party_monsters_status(player: "Player") -> None:
+    if not player.party_monsters:
+        print(f"{player.name} はまだ仲間モンスターを持っていません。")
+        return
+
+    print(f"===== {player.name} のパーティーメンバー詳細 =====")
+    for i, monster in enumerate(player.party_monsters):
+        print(f"--- {i+1}. ---")
+        monster.show_status()
+    print("=" * 30)
+
+
+def move_monster(player: "Player", from_idx: int, to_idx: int) -> bool:
+    if not (0 <= from_idx < len(player.party_monsters) and 0 <= to_idx < len(player.party_monsters)):
+        return False
+    monster = player.party_monsters.pop(from_idx)
+    player.party_monsters.insert(to_idx, monster)
+    return True
+
+
+def move_to_reserve(player: "Player", party_idx: int) -> bool:
+    if not (0 <= party_idx < len(player.party_monsters)):
+        return False
+    if len(player.party_monsters) <= 1:
+        return False
+    monster = player.party_monsters.pop(party_idx)
+    player.reserve_monsters.append(monster)
+    return True
+
+
+def move_from_reserve(player: "Player", reserve_idx: int) -> bool:
+    if not (0 <= reserve_idx < len(player.reserve_monsters)):
+        return False
+    monster = player.reserve_monsters.pop(reserve_idx)
+    player.party_monsters.append(monster)
+    return True
+
+
+def reset_formation(player: "Player") -> None:
+    while len(player.party_monsters) > 1:
+        player.reserve_monsters.append(player.party_monsters.pop())
+
+
+def show_items(player: "Player") -> None:
+    if not player.items:
+        print("アイテムを何も持っていない。")
+        return
+
+    print("===== 所持アイテム =====")
+    for i, item in enumerate(player.items, 1):
+        name = getattr(item, "name", str(item))
+        desc = getattr(item, "description", "")
+        print(f"{i}. {name} - {desc}")
+    print("=" * 20)
+
+
+def use_item(player: "Player", item_idx: int, target_monster: Monster) -> bool:
+    if not (0 <= item_idx < len(player.items)):
+        print("無効なアイテム番号です。")
+        return False
+
+    item = player.items[item_idx]
+    from .items import apply_item_effect
+
+    success = apply_item_effect(item, target_monster)
+    if success:
+        player.items.pop(item_idx)
+    return success
+
+
+def rest_at_inn(player: "Player", cost: int) -> bool:
+    if player.gold >= cost:
+        player.gold -= cost
+        print(f"{cost}G を支払い、宿屋に泊まった。")
+        for monster in player.party_monsters:
+            monster.hp = monster.max_hp
+            monster.mp = monster.max_mp
+            monster.is_alive = True
+        print("パーティは完全に回復した！")
+        return True
+    else:
+        print("お金が足りない！宿屋に泊まれない...")
+        return False
+
+
+def buy_item(player: "Player", item_id: str, price: int) -> bool:
+    if player.gold < price:
+        print("お金が足りない！")
+        return False
+    if item_id not in ALL_ITEMS:
+        print("そのアイテムは存在しない。")
+        return False
+    player.gold -= price
+    player.items.append(ALL_ITEMS[item_id])
+    print(f"{ALL_ITEMS[item_id].name} を {price}G で購入した。")
+    return True
+
+
+def buy_monster(player: "Player", monster_id: str, price: int) -> bool:
+    if player.gold < price:
+        print("お金が足りない！")
+        return False
+    if monster_id not in ALL_MONSTERS:
+        print("そのモンスターは存在しない。")
+        return False
+    player.gold -= price
+    add_monster_to_party(player, monster_id)
+    print(f"{ALL_MONSTERS[monster_id].name} を {price}G で仲間にした。")
+    return True
+
+
+def craft_equipment(player: "Player", equip_id: str):
+    recipe = CRAFTING_RECIPES.get(equip_id)
+    if not recipe:
+        print("その装備は作成できない。")
+        return None
+    for item_id, qty in recipe.items():
+        count = sum(1 for it in player.items if getattr(it, "item_id", None) == item_id)
+        if count < qty:
+            print("素材が足りない。")
+            return None
+    for item_id, qty in recipe.items():
+        removed = 0
+        for i in range(len(player.items) - 1, -1, -1):
+            if getattr(player.items[i], "item_id", None) == item_id and removed < qty:
+                player.items.pop(i)
+                removed += 1
+    new_equip = create_titled_equipment(equip_id)
+    if new_equip:
+        player.equipment_inventory.append(new_equip)
+        print(f"{new_equip.name} を作成した！")
+        return new_equip
+    print("装備の作成に失敗した。")
+    return None
+
+
+def equip_to_monster(player: "Player", party_idx: int, equip_id: str | None = None, slot: str | None = None) -> bool:
+    if not (0 <= party_idx < len(player.party_monsters)):
+        print("無効なモンスター番号")
+        return False
+
+    monster = player.party_monsters[party_idx]
+
+    if equip_id is None:
+        if slot is None or slot not in monster.equipment:
+            print("そのスロットには装備がない。")
+            return False
+        equip = monster.equipment.pop(slot)
+        player.equipment_inventory.append(equip)
+        print(f"{monster.name} の {slot} を外した。")
+        return True
+
+    equip = None
+    for e in player.equipment_inventory:
+        if isinstance(e, EquipmentInstance):
+            if e.instance_id == equip_id or e.base_item.equip_id == equip_id:
+                equip = e
+                break
+        else:
+            if getattr(e, "equip_id", None) == equip_id:
+                equip = e
+                break
+    if not equip:
+        print("その装備を所持していない。")
+        return False
+
+    monster.equip(equip)
+    player.equipment_inventory.remove(equip)
+    print(f"{monster.name} に {equip.name} を装備した。")
+    return True

--- a/backend/src/monster_rpg/save_manager.py
+++ b/backend/src/monster_rpg/save_manager.py
@@ -1,0 +1,258 @@
+"""Utility functions for saving and loading Player data."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Optional
+
+from .map_data import STARTING_LOCATION_ID
+from .monsters.monster_class import Monster
+from .monsters.monster_data import ALL_MONSTERS
+from .items.item_data import ALL_ITEMS
+from .items.equipment import (
+    create_titled_equipment,
+    EquipmentInstance,
+    Equipment,
+    ALL_EQUIPMENT,
+)
+from .items.titles import ALL_TITLES
+from .monster_book import MonsterBook
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .player import Player
+
+
+def save_game(player: "Player", db_name: str, user_id: Optional[int] = None) -> None:
+    """Persist the player's state to ``db_name``."""
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+
+    if user_id is not None:
+        player.user_id = user_id
+    if player.user_id is None:
+        player.user_id = 1
+
+    if player.db_id:
+        cursor.execute(
+            """
+            UPDATE player_data
+            SET name=?, player_level=?, exp=?, gold=?, current_location_id=?, user_id=?
+            WHERE id=?
+            """,
+            (
+                player.name,
+                player.player_level,
+                player.exp,
+                player.gold,
+                player.current_location_id,
+                player.user_id,
+                player.db_id,
+            ),
+        )
+    else:
+        cursor.execute(
+            """
+            INSERT INTO player_data (user_id, name, player_level, exp, gold, current_location_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                player.user_id,
+                player.name,
+                player.player_level,
+                player.exp,
+                player.gold,
+                player.current_location_id,
+            ),
+        )
+        player.db_id = cursor.lastrowid
+
+    cursor.execute("DELETE FROM party_monsters WHERE player_id=?", (player.db_id,))
+    for monster in player.party_monsters:
+        cursor.execute(
+            "INSERT INTO party_monsters (player_id, monster_id, level, exp, hp, max_hp, mp, max_mp) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                player.db_id,
+                monster.monster_id,
+                monster.level,
+                monster.exp,
+                monster.hp,
+                monster.max_hp,
+                monster.mp,
+                monster.max_mp,
+            ),
+        )
+
+    cursor.execute("DELETE FROM storage_monsters WHERE player_id=?", (player.db_id,))
+    for monster in player.reserve_monsters:
+        cursor.execute(
+            "INSERT INTO storage_monsters (player_id, monster_id, level, exp, hp, max_hp, mp, max_mp) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                player.db_id,
+                monster.monster_id,
+                monster.level,
+                monster.exp,
+                monster.hp,
+                monster.max_hp,
+                monster.mp,
+                monster.max_mp,
+            ),
+        )
+
+    cursor.execute("DELETE FROM player_items WHERE player_id=?", (player.db_id,))
+    for item in player.items:
+        item_id = getattr(item, "item_id", str(item))
+        cursor.execute(
+            "INSERT INTO player_items (player_id, item_id) VALUES (?, ?)",
+            (player.db_id, item_id),
+        )
+
+    cursor.execute("DELETE FROM player_equipment WHERE player_id=?", (player.db_id,))
+    for equip in player.equipment_inventory:
+        if hasattr(equip, "base_item"):
+            equip_id = equip.base_item.equip_id
+            title_id = equip.title.title_id if getattr(equip, "title", None) else None
+            instance_id = getattr(equip, "instance_id", None)
+        else:
+            equip_id = getattr(equip, "equip_id", str(equip))
+            title_id = None
+            instance_id = None
+        cursor.execute(
+            "INSERT INTO player_equipment (player_id, equip_id, title_id, instance_id) VALUES (?, ?, ?, ?)",
+            (player.db_id, equip_id, title_id, instance_id),
+        )
+
+    cursor.execute(
+        "DELETE FROM exploration_progress WHERE player_id=?", (player.db_id,)
+    )
+    for loc_id, prog in player.exploration_progress.items():
+        cursor.execute(
+            "INSERT INTO exploration_progress (player_id, location_id, progress) VALUES (?, ?, ?)",
+            (player.db_id, loc_id, prog),
+        )
+
+    cursor.execute(
+        "DELETE FROM monster_book_status WHERE player_id=?",
+        (player.db_id,),
+    )
+    all_ids = player.monster_book.seen.union(player.monster_book.captured)
+    for mid in all_ids:
+        cursor.execute(
+            "INSERT INTO monster_book_status (player_id, monster_id, seen, captured) VALUES (?, ?, ?, ?)",
+            (
+                player.db_id,
+                mid,
+                int(mid in player.monster_book.seen),
+                int(mid in player.monster_book.captured),
+            ),
+        )
+
+    conn.commit()
+    conn.close()
+    print(f"{player.name} のデータがセーブされました。")
+
+
+def load_game(db_name: str, user_id: int = 1) -> Optional["Player"]:
+    """Load the most recent save for the given user id."""
+    from .player import Player  # local import to avoid circular dependency
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, name, player_level, exp, gold, current_location_id, user_id FROM player_data WHERE user_id=? ORDER BY id DESC LIMIT 1",
+        (user_id,),
+    )
+    row = cursor.fetchone()
+
+    if row:
+        db_id, name, level, exp, gold, location_id, u_id = row
+        loaded_player = Player(name, player_level=level, gold=gold, user_id=u_id)
+        loaded_player.exp = exp
+        loaded_player.current_location_id = location_id
+        loaded_player.db_id = db_id
+
+        cursor.execute(
+            "SELECT monster_id, level, exp, hp, max_hp, mp, max_mp FROM party_monsters WHERE player_id=?",
+            (db_id,),
+        )
+        for monster_id, m_level, m_exp, hp, max_hp, mp, max_mp in cursor.fetchall():
+            if monster_id in ALL_MONSTERS:
+                monster = ALL_MONSTERS[monster_id].copy()
+                if monster.level < m_level:
+                    monster.advance_to_level(m_level, verbose=False)
+                monster.exp = m_exp
+                if max_hp is not None:
+                    monster.max_hp = max_hp
+                if hp is not None:
+                    monster.hp = hp
+                if max_mp is not None:
+                    monster.max_mp = max_mp
+                if mp is not None:
+                    monster.mp = mp
+                loaded_player.party_monsters.append(monster)
+
+        cursor.execute(
+            "SELECT monster_id, level, exp, hp, max_hp, mp, max_mp FROM storage_monsters WHERE player_id=?",
+            (db_id,),
+        )
+        for monster_id, m_level, m_exp, hp, max_hp, mp, max_mp in cursor.fetchall():
+            if monster_id in ALL_MONSTERS:
+                monster = ALL_MONSTERS[monster_id].copy()
+                if monster.level < m_level:
+                    monster.advance_to_level(m_level, verbose=False)
+                monster.exp = m_exp
+                if max_hp is not None:
+                    monster.max_hp = max_hp
+                if hp is not None:
+                    monster.hp = hp
+                if max_mp is not None:
+                    monster.max_mp = max_mp
+                if mp is not None:
+                    monster.mp = mp
+                loaded_player.reserve_monsters.append(monster)
+
+        cursor.execute(
+            "SELECT item_id FROM player_items WHERE player_id=?",
+            (db_id,),
+        )
+        for (item_id,) in cursor.fetchall():
+            if item_id in ALL_ITEMS:
+                loaded_player.items.append(ALL_ITEMS[item_id])
+
+        cursor.execute(
+            "SELECT equip_id, title_id, instance_id FROM player_equipment WHERE player_id=?",
+            (db_id,),
+        )
+        for equip_id, title_id, instance_id in cursor.fetchall():
+            if equip_id in ALL_EQUIPMENT:
+                base = ALL_EQUIPMENT[equip_id]
+                if title_id and title_id in ALL_TITLES:
+                    title = ALL_TITLES[title_id]
+                    equip = EquipmentInstance(base_item=base, title=title, instance_id=instance_id)
+                else:
+                    equip = base
+                loaded_player.equipment_inventory.append(equip)
+
+        cursor.execute(
+            "SELECT location_id, progress FROM exploration_progress WHERE player_id=?",
+            (db_id,),
+        )
+        for loc_id, prog in cursor.fetchall():
+            loaded_player.exploration_progress[loc_id] = prog
+
+        cursor.execute(
+            "SELECT monster_id, seen, captured FROM monster_book_status WHERE player_id=?",
+            (db_id,),
+        )
+        for mid, seen, captured in cursor.fetchall():
+            if seen:
+                loaded_player.monster_book.seen.add(mid)
+            if captured:
+                loaded_player.monster_book.captured.add(mid)
+
+        conn.close()
+        print(f"{name} のデータがロードされました。")
+        return loaded_player
+    else:
+        conn.close()
+        print("セーブデータが見つかりませんでした。")
+        return None

--- a/backend/src/monster_rpg/synthesis_manager.py
+++ b/backend/src/monster_rpg/synthesis_manager.py
@@ -1,0 +1,182 @@
+"""Functions for synthesizing monsters and items."""
+
+from __future__ import annotations
+
+import copy
+import random
+from typing import Tuple, Optional
+
+from .monsters.monster_class import Monster
+from .monsters.monster_data import ALL_MONSTERS
+from .monsters.synthesis_rules import (
+    SYNTHESIS_RECIPES,
+    SYNTHESIS_ITEMS_REQUIRED,
+    MONSTER_ITEM_RECIPES,
+    ITEM_ITEM_RECIPES,
+)
+from .items.item_data import ALL_ITEMS
+from .items.equipment import (
+    create_titled_equipment,
+    EquipmentInstance,
+    Equipment,
+    ALL_EQUIPMENT,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .player import Player
+
+DEBUG_MODE = False
+
+
+def synthesize_monster(player: "Player", monster1_idx: int, monster2_idx: int, item_id: str | None = None) -> Tuple[bool, str, Optional[Monster]]:
+    if not (0 <= monster1_idx < len(player.party_monsters) and 0 <= monster2_idx < len(player.party_monsters)):
+        return False, "無効なモンスターの選択です。", None
+    if monster1_idx == monster2_idx:
+        return False, "同じモンスター同士は合成できません。", None
+
+    parent1 = player.party_monsters[monster1_idx]
+    parent2 = player.party_monsters[monster2_idx]
+
+    if not parent1.monster_id or not parent2.monster_id:
+        return False, "エラー: 合成元のモンスターにIDが設定されていません。", None
+
+    id1_lower = parent1.monster_id.lower()
+    id2_lower = parent2.monster_id.lower()
+    recipe_key = tuple(sorted([id1_lower, id2_lower]))
+
+    if recipe_key in SYNTHESIS_RECIPES:
+        required_item = SYNTHESIS_ITEMS_REQUIRED.get(recipe_key)
+        if required_item:
+            item_index = next(
+                (i for i, itm in enumerate(player.items) if getattr(itm, "item_id", None) == required_item),
+                None,
+            )
+            if item_index is None:
+                item_name = ALL_ITEMS[required_item].name if required_item in ALL_ITEMS else required_item
+                return False, f"合成には {item_name} が必要だ。", None
+            player.items.pop(item_index)
+
+        result_monster_id = SYNTHESIS_RECIPES[recipe_key]
+        if result_monster_id in ALL_MONSTERS:
+            base_new_monster_template = ALL_MONSTERS[result_monster_id]
+            new_monster = base_new_monster_template.copy()
+            if new_monster is None:
+                return False, f"エラー: 合成結果のモンスター '{result_monster_id}' の生成に失敗しました。", None
+
+            inherited_skills = []
+            for parent in (parent1, parent2):
+                if parent.skills:
+                    skill = random.choice(parent.skills)
+                    current_names = [s.name for s in new_monster.skills + inherited_skills]
+                    if getattr(skill, "name", None) not in current_names:
+                        inherited_skills.append(copy.deepcopy(skill))
+            new_monster.skills.extend(inherited_skills)
+
+            avg_level = (parent1.level + parent2.level) / 2
+            hp_bonus = int(avg_level * 2)
+            atk_bonus = int(avg_level)
+            def_bonus = int(avg_level)
+            spd_bonus = int(avg_level * 0.5)
+            new_monster.max_hp += hp_bonus
+            new_monster.attack += atk_bonus
+            new_monster.defense += def_bonus
+            new_monster.speed += spd_bonus
+            new_monster.level = 1
+            new_monster.exp = 0
+            new_monster.hp = new_monster.max_hp
+            new_monster.is_alive = True
+
+            indices_to_remove = sorted([monster1_idx, monster2_idx], reverse=True)
+            removed_monster_names = []
+            for idx in indices_to_remove:
+                removed_monster_names.append(player.party_monsters.pop(idx).name)
+            player.party_monsters.append(new_monster)
+            player.monster_book.record_captured(new_monster.monster_id)
+            return True, f"{removed_monster_names[1]} と {removed_monster_names[0]} を合成して {new_monster.name} が誕生した！", new_monster
+        else:
+            return False, f"エラー: 合成結果のモンスターID '{result_monster_id}' がモンスター定義に存在しません。", None
+    else:
+        return False, f"{parent1.name} と {parent2.name} の組み合わせでは何も生まれなかった...", None
+
+
+def synthesize_monster_with_item(player: "Player", monster_idx: int, item_id: str) -> Tuple[bool, str, Optional[Monster]]:
+    if not (0 <= monster_idx < len(player.party_monsters)):
+        return False, "無効なモンスターの選択です。", None
+
+    item_index = next(
+        (i for i, it in enumerate(player.items) if getattr(it, "item_id", None) == item_id),
+        None,
+    )
+    if item_index is None:
+        return False, "そのアイテムを所持していない。", None
+
+    parent = player.party_monsters[monster_idx]
+    recipe_key = (parent.monster_id.lower(), item_id)
+
+    if recipe_key not in MONSTER_ITEM_RECIPES:
+        item_name = ALL_ITEMS[item_id].name if item_id in ALL_ITEMS else item_id
+        return False, f"{parent.name} と {item_name} では何も起こらなかった...", None
+
+    result_id = MONSTER_ITEM_RECIPES[recipe_key]
+    if result_id not in ALL_MONSTERS:
+        return False, f"エラー: 合成結果のモンスターID '{result_id}' が見つかりません。", None
+
+    new_mon = ALL_MONSTERS[result_id].copy()
+    if new_mon is None:
+        return False, f"エラー: 合成結果のモンスター '{result_id}' の生成に失敗しました。", None
+
+    removed_name = player.party_monsters.pop(monster_idx).name
+    player.items.pop(item_index)
+
+    new_mon.level = 1
+    new_mon.exp = 0
+    new_mon.hp = new_mon.max_hp
+    new_mon.is_alive = True
+    player.party_monsters.append(new_mon)
+    player.monster_book.record_captured(new_mon.monster_id)
+
+    item_name = ALL_ITEMS[item_id].name if item_id in ALL_ITEMS else item_id
+    return True, f"{removed_name} と {item_name} を合成して {new_mon.name} が誕生した！", new_mon
+
+
+def synthesize_items(player: "Player", item1_id: str, item2_id: str):
+    key = tuple(sorted([item1_id, item2_id]))
+    if key not in ITEM_ITEM_RECIPES:
+        return False, "その組み合わせでは何も起こらなかった...", None
+
+    def remove_material(iid: str):
+        for idx, it in enumerate(player.items):
+            if getattr(it, "item_id", None) == iid:
+                return player.items.pop(idx)
+        for idx, eq in enumerate(player.equipment_inventory):
+            if isinstance(eq, EquipmentInstance):
+                if eq.base_item.equip_id == iid:
+                    return player.equipment_inventory.pop(idx)
+            elif getattr(eq, "equip_id", None) == iid:
+                return player.equipment_inventory.pop(idx)
+        return None
+
+    mat1 = remove_material(item1_id)
+    if not mat1:
+        return False, "素材が足りない。", None
+    mat2 = remove_material(item2_id)
+    if not mat2:
+        if isinstance(mat1, (Equipment, EquipmentInstance)):
+            player.equipment_inventory.append(mat1)
+        else:
+            player.items.append(mat1)
+        return False, "素材が足りない。", None
+
+    result_id = ITEM_ITEM_RECIPES[key]
+    if result_id in ALL_ITEMS:
+        new_obj = ALL_ITEMS[result_id]
+        player.items.append(new_obj)
+    elif result_id in ALL_EQUIPMENT:
+        new_obj = create_titled_equipment(result_id)
+        if new_obj:
+            player.equipment_inventory.append(new_obj)
+    else:
+        return False, "レシピ結果が不明です。", None
+
+    return True, f"{getattr(new_obj, 'name', '')} を手に入れた！", new_obj

--- a/backend/src/monster_rpg/web/auth.py
+++ b/backend/src/monster_rpg/web/auth.py
@@ -3,6 +3,7 @@ import sqlite3
 from .. import database_setup
 from ..player import Player
 from ..monsters.monster_data import ALL_MONSTERS
+from .. import save_manager
 
 auth_bp = Blueprint('auth', __name__)
 
@@ -24,7 +25,7 @@ def start_game():
     for mid in ('slime', 'goblin', 'wolf'):
         if mid in ALL_MONSTERS:
             player.add_monster_to_party(mid)
-    player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+    save_manager.save_game(player, database_setup.DATABASE_NAME, user_id=user_id)
     session['user_id'] = user_id
     return redirect(url_for('main.play', user_id=user_id))
 
@@ -36,7 +37,7 @@ def load_existing():
         u_id = int(user_id)
     except (ValueError, TypeError):
         return 'invalid user id', 400
-    player = Player.load_game(database_setup.DATABASE_NAME, user_id=u_id)
+    player = save_manager.load_game(database_setup.DATABASE_NAME, user_id=u_id)
     if not player:
         return 'save not found', 404
     session['user_id'] = u_id
@@ -60,7 +61,7 @@ def login():
             message='ユーザー名またはパスワードが違います',
             user_id=None,
         )
-    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    player = save_manager.load_game(database_setup.DATABASE_NAME, user_id=user_id)
     if not player:
         return render_template(
             'result.html',

--- a/backend/src/monster_rpg/web/market.py
+++ b/backend/src/monster_rpg/web/market.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 
 from .. import database_setup
 from ..player import Player
+from .. import save_manager
 from ..trading import list_item, list_monster_from_reserve, get_listings, buy_listing
 
 market_bp = Blueprint('market', __name__)
@@ -14,7 +15,7 @@ def listings():
 
 @market_bp.route('/market/list_item/<int:user_id>', methods=['POST'])
 def list_item_route(user_id):
-    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    player = save_manager.load_game(database_setup.DATABASE_NAME, user_id=user_id)
     if not player:
         return jsonify({'error': 'player not found'}), 404
     if not request.is_json:
@@ -24,14 +25,14 @@ def list_item_route(user_id):
     price = int(data.get('price', -1))
     success = list_item(player, idx, price)
     if success:
-        player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        save_manager.save_game(player, database_setup.DATABASE_NAME, user_id=user_id)
         return jsonify({'success': True})
     return jsonify({'success': False}), 400
 
 
 @market_bp.route('/market/list_monster/<int:user_id>', methods=['POST'])
 def list_monster_route(user_id):
-    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    player = save_manager.load_game(database_setup.DATABASE_NAME, user_id=user_id)
     if not player:
         return jsonify({'error': 'player not found'}), 404
     if not request.is_json:
@@ -41,18 +42,18 @@ def list_monster_route(user_id):
     price = int(data.get('price', -1))
     success = list_monster_from_reserve(player, idx, price)
     if success:
-        player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        save_manager.save_game(player, database_setup.DATABASE_NAME, user_id=user_id)
         return jsonify({'success': True})
     return jsonify({'success': False}), 400
 
 
 @market_bp.route('/market/buy/<int:user_id>/<int:listing_id>', methods=['POST'])
 def buy_route(user_id, listing_id):
-    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    player = save_manager.load_game(database_setup.DATABASE_NAME, user_id=user_id)
     if not player:
         return jsonify({'error': 'player not found'}), 404
     success = buy_listing(player, listing_id)
     if success:
-        player.save_game(database_setup.DATABASE_NAME, user_id=user_id)
+        save_manager.save_game(player, database_setup.DATABASE_NAME, user_id=user_id)
         return jsonify({'success': True})
     return jsonify({'success': False}), 400

--- a/backend/tests/test_continue_explore_redirect.py
+++ b/backend/tests/test_continue_explore_redirect.py
@@ -4,6 +4,7 @@ import unittest
 from monster_rpg import database_setup
 from monster_rpg.web_main import app
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 
 class ContinueExploreRedirectTests(unittest.TestCase):
     def setUp(self):
@@ -15,7 +16,7 @@ class ContinueExploreRedirectTests(unittest.TestCase):
         self.user_id = database_setup.create_user('tester', 'pw')
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):

--- a/backend/tests/test_equip_route.py
+++ b/backend/tests/test_equip_route.py
@@ -4,6 +4,7 @@ import unittest
 from monster_rpg import database_setup
 from monster_rpg.web_main import app
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.items.equipment import ALL_EQUIPMENT
 
 class EquipRouteTests(unittest.TestCase):
@@ -18,7 +19,7 @@ class EquipRouteTests(unittest.TestCase):
         player = Player('Tester', user_id=self.user_id)
         player.add_monster_to_party('slime')
         player.equipment_inventory.append(ALL_EQUIPMENT['bronze_sword'])
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):
@@ -29,7 +30,7 @@ class EquipRouteTests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         data = resp.get_json()
         self.assertTrue(data['success'])
-        loaded = Player.load_game(self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertEqual(len(loaded.equipment_inventory), 0)
         self.assertIn('weapon', data['monster_equipment'])
         self.assertEqual(data['monster_equipment']['weapon'], ALL_EQUIPMENT['bronze_sword'].name)

--- a/backend/tests/test_hidden_connections.py
+++ b/backend/tests/test_hidden_connections.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from monster_rpg import database_setup
 from monster_rpg.web_main import app
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.map_data import LOCATIONS
 
 class HiddenConnectionsTests(unittest.TestCase):
@@ -19,7 +20,7 @@ class HiddenConnectionsTests(unittest.TestCase):
         player = Player('Tester', user_id=self.user_id)
         player.current_location_id = 'deep_forest'
         player.increase_exploration('deep_forest', 90)
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):

--- a/backend/tests/test_item_monster_synthesis.py
+++ b/backend/tests/test_item_monster_synthesis.py
@@ -3,6 +3,7 @@ import unittest
 import os
 
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.items.item_data import ALL_ITEMS
 from monster_rpg.monsters.monster_data import ALL_MONSTERS
 from monster_rpg import database_setup
@@ -46,7 +47,7 @@ class ItemMonsterSynthesisRouteTests(unittest.TestCase):
         player.add_monster_to_party('slime')
         player.items.append(ALL_ITEMS['dragon_scale'])
         player.items.append(ALL_ITEMS['magic_stone'])
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):
@@ -83,7 +84,7 @@ class ItemMonsterSynthesisRouteTests(unittest.TestCase):
         from monster_rpg.items.equipment import ALL_EQUIPMENT
         self.assertTrue(data['name'].endswith(ALL_EQUIPMENT['bronze_sword'].name))
 
-        loaded = Player.load_game(self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertEqual(len(loaded.equipment_inventory), 1)
 
 if __name__ == '__main__':

--- a/backend/tests/test_party_formation.py
+++ b/backend/tests/test_party_formation.py
@@ -3,6 +3,7 @@ import unittest
 
 from monster_rpg import database_setup
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.monsters.monster_data import ALL_MONSTERS
 from monster_rpg.web_main import app
 
@@ -33,7 +34,7 @@ class FormationRouteTests(unittest.TestCase):
         for mid in ('slime', 'goblin', 'wolf'):
             if mid in ALL_MONSTERS:
                 player.add_monster_to_party(mid)
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):
@@ -45,14 +46,14 @@ class FormationRouteTests(unittest.TestCase):
             data={'order': '[1,2,0]', 'reserve': '[]'}
         )
         self.assertEqual(resp.status_code, 200)
-        player = Player.load_game(self.db_path, user_id=self.user_id)
+        player = save_manager.load_game(self.db_path, user_id=self.user_id)
         ids = [m.monster_id for m in player.party_monsters]
         self.assertEqual(ids, ['goblin', 'wolf', 'slime'])
 
     def test_reset_formation(self):
         resp = self.client.post(f'/formation/{self.user_id}', data={'reset': '1'})
         self.assertEqual(resp.status_code, 200)
-        player = Player.load_game(self.db_path, user_id=self.user_id)
+        player = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertEqual([m.monster_id for m in player.party_monsters], ['slime'])
         self.assertEqual(
             [m.monster_id for m in player.reserve_monsters],

--- a/backend/tests/test_required_item.py
+++ b/backend/tests/test_required_item.py
@@ -4,6 +4,7 @@ import unittest
 from monster_rpg import database_setup
 from monster_rpg.web_main import app
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.items.item_data import ALL_ITEMS
 
 
@@ -24,28 +25,28 @@ class RequiredItemMovementTests(unittest.TestCase):
     def test_block_without_item(self):
         player = Player("Tester", user_id=self.user_id)
         player.current_location_id = "sky_isle"
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
         resp = self.client.post(
             f"/move/{self.user_id}", data={"dest": "sky_isle_inner_sanctum"}
         )
         self.assertEqual(resp.status_code, 200)
         self.assertIn("celestial_feather", resp.get_data(as_text=True))
-        loaded = Player.load_game(self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertEqual(loaded.current_location_id, "sky_isle")
 
     def test_move_with_item(self):
         player = Player("Tester", user_id=self.user_id)
         player.current_location_id = "sky_isle"
         player.items.append(ALL_ITEMS["celestial_feather"])
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
         resp = self.client.post(
             f"/move/{self.user_id}", data={"dest": "sky_isle_inner_sanctum"}
         )
         self.assertEqual(resp.status_code, 302)
         self.assertTrue(resp.headers["Location"].endswith(f"/play/{self.user_id}"))
-        loaded = Player.load_game(self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertEqual(loaded.current_location_id, "sky_isle_inner_sanctum")
 
 

--- a/backend/tests/test_save_load.py
+++ b/backend/tests/test_save_load.py
@@ -3,6 +3,7 @@ import unittest
 
 from monster_rpg import database_setup
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.monsters.monster_data import ALL_MONSTERS
 from monster_rpg.items.item_data import ALL_ITEMS
 from monster_rpg.items.equipment import ALL_EQUIPMENT
@@ -27,8 +28,8 @@ class SaveLoadTests(unittest.TestCase):
         player.add_monster_to_party('goblin')
         player.items.append(ALL_ITEMS['small_potion'])
 
-        player.save_game(self.db_path)
-        loaded = Player.load_game(self.db_path, user_id=self.user1)
+        save_manager.save_game(player, self.db_path)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user1)
 
         self.assertIsNotNone(loaded)
         monster_ids = sorted(m.monster_id for m in loaded.party_monsters)
@@ -39,14 +40,14 @@ class SaveLoadTests(unittest.TestCase):
     def test_multiple_users_separate_saves(self):
         p1 = Player('A', user_id=self.user1)
         p1.add_monster_to_party('slime')
-        p1.save_game(self.db_path)
+        save_manager.save_game(p1, self.db_path)
 
         p2 = Player('B', user_id=self.user2)
         p2.add_monster_to_party('goblin')
-        p2.save_game(self.db_path)
+        save_manager.save_game(p2, self.db_path)
 
-        l1 = Player.load_game(self.db_path, user_id=self.user1)
-        l2 = Player.load_game(self.db_path, user_id=self.user2)
+        l1 = save_manager.load_game(self.db_path, user_id=self.user1)
+        l2 = save_manager.load_game(self.db_path, user_id=self.user2)
 
         self.assertEqual(len(l1.party_monsters), 1)
         self.assertEqual(l1.party_monsters[0].monster_id, 'slime')
@@ -56,17 +57,17 @@ class SaveLoadTests(unittest.TestCase):
     def test_exploration_progress_saved_and_loaded(self):
         player = Player('Explorer', user_id=self.user1)
         player.increase_exploration('forest_entrance', 40)
-        player.save_game(self.db_path)
+        save_manager.save_game(player, self.db_path)
 
-        loaded = Player.load_game(self.db_path, user_id=self.user1)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user1)
         self.assertEqual(loaded.get_exploration('forest_entrance'), 40)
 
     def test_save_and_load_equipment(self):
         player = Player('EquipTester', user_id=self.user1)
         player.equipment_inventory.append(ALL_EQUIPMENT['bronze_sword'])
-        player.save_game(self.db_path)
+        save_manager.save_game(player, self.db_path)
 
-        loaded = Player.load_game(self.db_path, user_id=self.user1)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user1)
         self.assertEqual(len(loaded.equipment_inventory), 1)
         self.assertEqual(loaded.equipment_inventory[0].equip_id, 'bronze_sword')
 
@@ -76,9 +77,9 @@ class SaveLoadTests(unittest.TestCase):
         m = player.party_monsters[0]
         m.hp -= 2
         m.mp -= 1
-        player.save_game(self.db_path)
+        save_manager.save_game(player, self.db_path)
 
-        loaded = Player.load_game(self.db_path, user_id=self.user1)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user1)
         lm = loaded.party_monsters[0]
         self.assertEqual(lm.hp, m.hp)
         self.assertEqual(lm.max_hp, m.max_hp)

--- a/backend/tests/test_synthesis_inheritance.py
+++ b/backend/tests/test_synthesis_inheritance.py
@@ -3,6 +3,7 @@ import unittest
 import os
 
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.monsters.monster_data import ALL_MONSTERS
 from monster_rpg import database_setup
 from monster_rpg.web_main import app
@@ -43,7 +44,7 @@ class SynthesisRouteTests(unittest.TestCase):
         player = Player('Tester', user_id=self.user_id)
         player.add_monster_to_party('slime')
         player.add_monster_to_party('wolf')
-        player.save_game(self.db_path, user_id=self.user_id)
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):
@@ -63,7 +64,7 @@ class SynthesisRouteTests(unittest.TestCase):
         data = resp.get_json()
         self.assertTrue(data['success'])
         self.assertEqual(data['name'], ALL_MONSTERS['water_wolf'].name)
-        loaded = Player.load_game(self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertIn('water_wolf', loaded.monster_book.captured)
 
 if __name__ == '__main__':

--- a/backend/tests/test_trade.py
+++ b/backend/tests/test_trade.py
@@ -4,6 +4,7 @@ import unittest
 from monster_rpg import database_setup
 from monster_rpg.web_main import app
 from monster_rpg.player import Player
+from monster_rpg import save_manager
 from monster_rpg.items.item_data import ALL_ITEMS
 from monster_rpg.monsters.monster_data import ALL_MONSTERS
 
@@ -25,11 +26,11 @@ class TradeTests(unittest.TestCase):
         seller.move_to_reserve(0)
         mon = seller.reserve_monsters[0]
         mon.gain_exp(mon.calculate_exp_to_next_level())
-        seller.save_game(self.db_path, user_id=self.seller_id)
+        save_manager.save_game(seller, self.db_path, user_id=self.seller_id)
 
         buyer = Player('Buyer', user_id=self.buyer_id, gold=200)
         buyer.add_monster_to_party('goblin')
-        buyer.save_game(self.db_path, user_id=self.buyer_id)
+        save_manager.save_game(buyer, self.db_path, user_id=self.buyer_id)
 
     def tearDown(self):
         if os.path.exists(self.db_path):
@@ -52,7 +53,7 @@ class TradeTests(unittest.TestCase):
         resp = self.client.post(f'/market/buy/{self.buyer_id}/{monster_listing["id"]}')
         self.assertEqual(resp.status_code, 200)
 
-        buyer = Player.load_game(self.db_path, user_id=self.buyer_id)
+        buyer = save_manager.load_game(self.db_path, user_id=self.buyer_id)
         self.assertEqual(len(buyer.items), 1)
         self.assertEqual(buyer.items[0].item_id, 'small_potion')
         self.assertTrue(any(m.monster_id == 'slime' for m in buyer.party_monsters))


### PR DESCRIPTION
## Summary
- add new manager modules for saving, party operations, synthesis, and evolution
- trim `Player` class to delegate to these managers
- update web handlers and tests to use the managers
- keep functionality via delegation while reducing player module size

## Testing
- `pip install Flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558ba793708321985e3fead0314cd6