### PR TITLE
Refactor stats to avoid buff/equipment conflicts

### DIFF
--- a/backend/src/monster_rpg/battle.py
+++ b/backend/src/monster_rpg/battle.py
@@ -37,15 +37,18 @@ def _status_heal(monster: Monster, amount: int):
         print(f"{monster.name} は {healed} 回復した！ (HP: {monster.hp})")
 
 def _slow_apply(monster: Monster):
-    monster.speed = max(1, monster.speed - 5)
+    monster.apply_buff('speed', -5, 0)
+    if monster.speed < 1:
+        monster.apply_buff('speed', 1 - monster.speed, 0)
+
     def revert(m: Monster = monster):
-        m.speed += 5
+        m.apply_buff('speed', 5, 0)
     return revert
 
 def _charge_apply(monster: Monster):
-    monster.defense -= 5
+    monster.apply_buff('defense', -5, 0)
     def revert(m: Monster = monster):
-        m.defense += 5
+        m.apply_buff('defense', 5, 0)
     return revert
 
 STATUS_DEFINITIONS = {

--- a/backend/src/monster_rpg/synthesis_manager.py
+++ b/backend/src/monster_rpg/synthesis_manager.py
@@ -79,9 +79,9 @@ def synthesize_monster(player: "Player", monster1_idx: int, monster2_idx: int, i
             def_bonus = int(avg_level)
             spd_bonus = int(avg_level * 0.5)
             new_monster.max_hp += hp_bonus
-            new_monster.attack += atk_bonus
-            new_monster.defense += def_bonus
-            new_monster.speed += spd_bonus
+            new_monster.base_attack += atk_bonus
+            new_monster.base_defense += def_bonus
+            new_monster.base_speed += spd_bonus
             new_monster.level = 1
             new_monster.exp = 0
             new_monster.hp = new_monster.max_hp


### PR DESCRIPTION
## Summary
- refactor `Monster` stats to store base values
- compute attack/defense/speed/magic dynamically with equipment and buffs
- update buff helpers and status effects
- adjust synthesis stat bonuses

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856031ebf8483218d0bd7cec5ee6887