### PR TITLE
Add battle item usage

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -27,19 +27,25 @@ function setupBattleUI() {
         if (!actionSel) return;
         const enemySel = document.querySelector('select[name="target_enemy"]');
         const allySel = document.querySelector('select[name="target_ally"]');
+        const itemSel = document.querySelector('select[name="item_idx"]');
         const opt = actionSel.selectedOptions[0];
         const target = opt.dataset.target || 'enemy';
         const scope = opt.dataset.scope || 'single';
 
+        const isItem = opt.value === 'item';
+
         if (target === 'none' || scope === 'all') {
             enemySel.style.display = 'none';
             allySel.style.display = 'none';
+            if (itemSel) itemSel.style.display = 'none';
         } else if (target === 'ally') {
             enemySel.style.display = 'none';
             allySel.style.display = '';
+            if (itemSel) itemSel.style.display = isItem ? '' : 'none';
         } else {
             enemySel.style.display = '';
             allySel.style.display = 'none';
+            if (itemSel) itemSel.style.display = 'none';
         }
     }
     const actionSel = document.getElementById('action');
@@ -210,6 +216,13 @@ function applyBattleData(data) {
                 opt.textContent = sk.name;
                 actionSel.appendChild(opt);
             });
+
+            const itemOpt = document.createElement('option');
+            itemOpt.value = 'item';
+            itemOpt.dataset.target = 'ally';
+            itemOpt.dataset.scope = 'single';
+            itemOpt.textContent = 'アイテム';
+            actionSel.appendChild(itemOpt);
 
             const scoutOpt = document.createElement('option');
             scoutOpt.value = 'scout';

--- a/backend/src/monster_rpg/templates/battle_turn.html
+++ b/backend/src/monster_rpg/templates/battle_turn.html
@@ -72,6 +72,7 @@
                         {% set s_idx = loop.index0 %}
                         <option value="skill{{ s_idx }}" data-target="{{ sk.target }}" data-scope="{{ sk.scope }}">{{ sk.name }}</option>
                         {% endfor %}
+                        <option value="item" data-target="ally" data-scope="single">アイテム</option>
                         <option value="scout" data-target="enemy" data-scope="single">スカウト</option>
                         <option value="run" data-target="none" data-scope="none">逃げる</option>
                     </select>
@@ -84,6 +85,11 @@
                         <select name="target_ally">
                             {% for a in player_party if a.is_alive %}
                             <option value="{{ loop.index0 }}">{{ a.name }}</option>
+                            {% endfor %}
+                        </select>
+                        <select name="item_idx">
+                            {% for it in player.items %}
+                            <option value="{{ loop.index0 }}">{{ it.name }}</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/backend/src/monster_rpg/web/battle.py
+++ b/backend/src/monster_rpg/web/battle.py
@@ -117,6 +117,19 @@ class Battle:
                 target.is_alive = False
                 self.log.append({'type': 'info', 'message': f'{target.name}をたおした！'})
             return
+        if act.get('type') == 'item':
+            idx = act.get('item_idx', -1)
+            t_idx = act.get('target_ally', 0)
+            if self.player and 0 <= idx < len(self.player.items) and 0 <= t_idx < len(self.player_party):
+                item_name = self.player.items[idx].name
+                target = self.player_party[t_idx]
+                success = self.player.use_item(idx, target)
+                msg = f'{actor.name}は {item_name} を使った。' if success else f'{actor.name}は {item_name} を使えなかった。'
+            else:
+                success = False
+                msg = f'{actor.name} はアイテムを使えなかった。'
+            self.log.append({'type': 'info', 'message': msg})
+            return
         if act.get('type') == 'scout':
             t_idx = act.get('target_enemy', -1)
             if 0 <= t_idx < len(self.enemy_party) and self.enemy_party[t_idx].is_alive:
@@ -240,6 +253,18 @@ def battle(user_id):
                 except ValueError:
                     tgt_a = 0
                 action = {'type': 'skill', 'skill': s_idx, 'target_enemy': tgt_e, 'target_ally': tgt_a}
+            elif act_val == 'item':
+                idx_val = data_src.get('item_idx', '-1')
+                tgt_a = data_src.get('target_ally', '0')
+                try:
+                    idx_val = int(idx_val)
+                except ValueError:
+                    idx_val = -1
+                try:
+                    tgt_a = int(tgt_a)
+                except ValueError:
+                    tgt_a = 0
+                action = {'type': 'item', 'item_idx': idx_val, 'target_ally': tgt_a}
             elif act_val == 'scout':
                 tgt = data_src.get('target_enemy', '-1')
                 try:

--- a/backend/tests/test_battle_item_use.py
+++ b/backend/tests/test_battle_item_use.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from monster_rpg import database_setup
+from monster_rpg.web_main import app, Battle, active_battles
+from monster_rpg.player import Player
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.items.item_data import ALL_ITEMS
+
+class BattleItemUseTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_item_battle.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.user_id = database_setup.create_user('tester', 'pw')
+        self.client = app.test_client()
+        player = Player('Tester', user_id=self.user_id)
+        hero = Monster('Hero', hp=50, attack=5, defense=2, speed=10)
+        hero.hp = 20
+        player.party_monsters.append(hero)
+        player.items.append(ALL_ITEMS['small_potion'])
+        enemy = Monster('Slime', hp=10, attack=3, defense=1)
+        battle_obj = Battle(player.party_monsters, [enemy], player)
+        active_battles[self.user_id] = battle_obj
+
+    def tearDown(self):
+        active_battles.pop(self.user_id, None)
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_item_use_consumes_inventory_and_heals(self):
+        resp = self.client.post(
+            f'/battle/{self.user_id}',
+            json={'action': 'item', 'item_idx': 0, 'target_ally': 0}
+        )
+        self.assertEqual(resp.status_code, 200)
+        battle_obj = active_battles[self.user_id]
+        hero = battle_obj.player_party[0]
+        self.assertEqual(len(battle_obj.player.items), 0)
+        self.assertGreater(hero.hp, 20)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable using items mid-battle
- render item selector and option on the battle screen
- update JavaScript to toggle selectors and send item index
- support `item` actions in battle backend
- test that battle item usage consumes inventory and heals HP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858aeb4d0a08321ba878ef0de951a26