### PR TITLE
Add tab based skill UI

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.css
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.css
@@ -197,3 +197,16 @@ button:hover { background: #004cd1; }
     transform: translateY(-40px);
     opacity: 1;
 }
+
+/* --- Skill selection UI --- */
+#skill-ui { display: none; margin-top: .5rem; }
+.skill-tabs { display: flex; border-bottom: 1px solid #555; margin-bottom: .5rem; }
+.skill-tab { flex: 1; padding: .3rem .5rem; background: #333; border: none; color: #eee; cursor: pointer; border-bottom: 2px solid transparent; }
+.skill-tab.active { background: #004cd1; border-color: #88c0ff; }
+.skill-panels { }
+.skill-panel.hidden { display: none; }
+.skill-panel { display: flex; flex-wrap: wrap; gap: .25rem; }
+.skill-btn { background: #444; border: 1px solid #777; border-radius: 4px; padding: .3rem .6rem; cursor: pointer; }
+.skill-btn.selected { background: #0066cc; }
+.skill-btn.disabled { opacity: 0.5; cursor: not-allowed; }
+.skill-desc { margin-top: .5rem; min-height: 1.5rem; font-size: .9rem; color: #fff; }

--- a/backend/src/monster_rpg/templates/battle_turn.html
+++ b/backend/src/monster_rpg/templates/battle_turn.html
@@ -68,14 +68,17 @@
                     <label for="action">{{ current_actor.name }}:</label>
                     <select name="action" id="action">
                         <option value="attack" data-target="enemy" data-scope="single">攻撃</option>
-                        {% for sk in current_actor.skills %}
-                        {% set s_idx = loop.index0 %}
-                        <option value="skill{{ s_idx }}" data-target="{{ sk.target }}" data-scope="{{ sk.scope }}">{{ sk.name }}</option>
-                        {% endfor %}
+                        <option value="skill" data-target="enemy" data-scope="single">スキル</option>
                         <option value="item" data-target="ally" data-scope="single">アイテム</option>
                         <option value="scout" data-target="enemy" data-scope="single">スカウト</option>
                         <option value="run" data-target="none" data-scope="none">逃げる</option>
                     </select>
+                    <div id="skill-ui">
+                        <input type="hidden" name="selected_skill_id" id="selected-skill-id">
+                        <div id="skill-tabs" class="skill-tabs"></div>
+                        <div id="skill-panels" class="skill-panels"></div>
+                        <div id="skill-desc" class="skill-desc"></div>
+                    </div>
                     <div>
                         <select name="target_enemy">
                             {% for e in enemy_party if e.is_alive %}


### PR DESCRIPTION
## Summary
- switch to tabbed skill selection in the battle UI
- refresh skills with buildSkillUI in JS
- support toggling skill panels on action change
- style the new tabs and buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b0549ecc8321a3c773252bbb9e21