### PR TITLE
Display status effects in battle views

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -84,12 +84,19 @@ function setupBattleUI() {
         attack: document.getElementById('detail-attack'),
         defense: document.getElementById('detail-defense'),
         speed: document.getElementById('detail-speed'),
+        statuses: document.getElementById('detail-statuses'),
     };
     document.querySelectorAll('.enemy.battle-unit').forEach(el => {
         el.addEventListener('click', () => {
             for (const key in fields) {
                 const dataKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
                 fields[key].textContent = el.dataset[dataKey] || '';
+            }
+            try {
+                const list = JSON.parse(el.dataset.statuses || '[]');
+                fields.statuses.textContent = list.map(s => `${s.display}(${s.remaining})`).join('、');
+            } catch (e) {
+                fields.statuses.textContent = '';
             }
             detailPanel.classList.add('open');
         });
@@ -144,6 +151,7 @@ function updateUnitList(units, infoList) {
         const prevHp = parseInt(unit.dataset.hp || '0');
         unit.dataset.hp = info.hp;
         unit.dataset.mp = info.mp;
+        unit.dataset.statuses = JSON.stringify(info.status_effects || []);
         if (!info.alive) unit.classList.add('down');
         const fill = unit.querySelector('.hp-fill');
         const pct = Math.round(info.hp / info.max_hp * 100);

--- a/backend/src/monster_rpg/templates/battle_turn.html
+++ b/backend/src/monster_rpg/templates/battle_turn.html
@@ -17,7 +17,8 @@
                  data-down="{{ not e.is_alive }}" data-unit-id="enemy-{{ loop.index0 }}"
                  data-name="{{ e.name }}" data-level="{{ e.level }}" data-hp="{{ e.hp }}"
                  data-max-hp="{{ e.max_hp }}" data-mp="{{ e.mp }}" data-max-mp="{{ e.max_mp }}"
-                 data-attack="{{ e.attack }}" data-defense="{{ e.defense }}" data-speed="{{ e.speed }}">
+                 data-attack="{{ e.attack }}" data-defense="{{ e.defense }}" data-speed="{{ e.speed }}"
+                 data-statuses="{{ e.status_effects|tojson }}">
                 
                 {% if e.image_filename %}
                     <img class="unit-img" src="{{ url_for('static', filename='images/' + e.image_filename) }}" alt="{{ e.name }}">
@@ -44,7 +45,8 @@
             {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
 
                 <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m is sameas current_actor %} active-turn{% endif %}"
-                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}" data-mp="{{ m.mp }}" data-max-mp="{{ m.max_mp }}">
+                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}" data-mp="{{ m.mp }}" data-max-mp="{{ m.max_mp }}"
+                     data-statuses="{{ m.status_effects|tojson }}">
                     
                     {% if m.image_filename %}
                         <img class="unit-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
@@ -123,6 +125,7 @@
             <li>攻撃 <span id="detail-attack"></span></li>
             <li>防御 <span id="detail-defense"></span></li>
             <li>素早さ <span id="detail-speed"></span></li>
+            <li>状態 <span id="detail-statuses"></span></li>
         </ul>
     </div>
 </div>

--- a/backend/src/monster_rpg/web/battle.py
+++ b/backend/src/monster_rpg/web/battle.py
@@ -1,5 +1,6 @@
 import random
 from flask import Blueprint, render_template, redirect, url_for, request, jsonify
+from ..battle import STATUS_DEFINITIONS
 from .. import database_setup
 from ..player import Player
 from .. import save_manager
@@ -329,16 +330,72 @@ def battle(user_id):
         if request.method == 'POST':
             html = render_template('battle.html', messages=msgs, user_id=user_id)
             hp_vals = {
-                'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.player_party],
-                'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+                'player': [{
+                    'hp': m.hp,
+                    'max_hp': m.max_hp,
+                    'mp': m.mp,
+                    'max_mp': m.max_mp,
+                    'alive': m.is_alive,
+                    'status_effects': [
+                        {
+                            'name': e['name'],
+                            'remaining': e['remaining'],
+                            'display': STATUS_DEFINITIONS.get(e['name'], {}).get('message', e['name'])
+                        }
+                        for e in m.status_effects
+                    ],
+                } for m in battle_obj.player_party],
+                'enemy': [{
+                    'hp': m.hp,
+                    'max_hp': m.max_hp,
+                    'mp': m.mp,
+                    'max_mp': m.max_mp,
+                    'alive': m.is_alive,
+                    'status_effects': [
+                        {
+                            'name': e['name'],
+                            'remaining': e['remaining'],
+                            'display': STATUS_DEFINITIONS.get(e['name'], {}).get('message', e['name'])
+                        }
+                        for e in m.status_effects
+                    ],
+                } for m in battle_obj.enemy_party],
             }
             return jsonify({'hp_values': hp_vals, 'log': battle_obj.log, 'finished': True, 'turn': battle_obj.turn, 'html': html})
         return render_template('battle.html', messages=msgs, user_id=user_id)
     current_actor = battle_obj.current_actor()
     if request.method == 'POST':
         hp_vals = {
-            'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.player_party],
-            'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+            'player': [{
+                'hp': m.hp,
+                'max_hp': m.max_hp,
+                'mp': m.mp,
+                'max_mp': m.max_mp,
+                'alive': m.is_alive,
+                'status_effects': [
+                    {
+                        'name': e['name'],
+                        'remaining': e['remaining'],
+                        'display': STATUS_DEFINITIONS.get(e['name'], {}).get('message', e['name'])
+                    }
+                    for e in m.status_effects
+                ],
+            } for m in battle_obj.player_party],
+            'enemy': [{
+                'hp': m.hp,
+                'max_hp': m.max_hp,
+                'mp': m.mp,
+                'max_mp': m.max_mp,
+                'alive': m.is_alive,
+                'status_effects': [
+                    {
+                        'name': e['name'],
+                        'remaining': e['remaining'],
+                        'display': STATUS_DEFINITIONS.get(e['name'], {}).get('message', e['name'])
+                    }
+                    for e in m.status_effects
+                ],
+            } for m in battle_obj.enemy_party],
         }
         actor = battle_obj.current_actor()
         actor_data = None
@@ -360,8 +417,36 @@ def battle_json(user_id):
     if not battle_obj:
         return jsonify({'error': 'no_active_battle'}), 404
     hp_vals = {
-        'player': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.player_party],
-        'enemy': [{'hp': m.hp, 'max_hp': m.max_hp, 'mp': m.mp, 'max_mp': m.max_mp, 'alive': m.is_alive} for m in battle_obj.enemy_party],
+        'player': [{
+            'hp': m.hp,
+            'max_hp': m.max_hp,
+            'mp': m.mp,
+            'max_mp': m.max_mp,
+            'alive': m.is_alive,
+            'status_effects': [
+                {
+                    'name': e['name'],
+                    'remaining': e['remaining'],
+                    'display': STATUS_DEFINITIONS.get(e['name'], {}).get('message', e['name'])
+                }
+                for e in m.status_effects
+            ],
+        } for m in battle_obj.player_party],
+        'enemy': [{
+            'hp': m.hp,
+            'max_hp': m.max_hp,
+            'mp': m.mp,
+            'max_mp': m.max_mp,
+            'alive': m.is_alive,
+            'status_effects': [
+                {
+                    'name': e['name'],
+                    'remaining': e['remaining'],
+                    'display': STATUS_DEFINITIONS.get(e['name'], {}).get('message', e['name'])
+                }
+                for e in m.status_effects
+            ],
+        } for m in battle_obj.enemy_party],
     }
     if battle_obj.finished:
         html = render_template('battle.html', messages=battle_obj.log, user_id=user_id)

--- a/backend/tests/test_web_battle_get_json.py
+++ b/backend/tests/test_web_battle_get_json.py
@@ -33,6 +33,8 @@ class BattleGetJsonTests(unittest.TestCase):
         data = resp.get_json()
         self.assertIsInstance(data, dict)
         self.assertIn('hp_values', data)
+        self.assertIn('status_effects', data['hp_values']['player'][0])
+        self.assertIn('status_effects', data['hp_values']['enemy'][0])
         self.assertIn('log', data)
         self.assertIn('finished', data)
 

--- a/backend/tests/test_web_battle_json.py
+++ b/backend/tests/test_web_battle_json.py
@@ -33,6 +33,8 @@ class BattleViewJsonTests(unittest.TestCase):
         data = resp.get_json()
         self.assertIsInstance(data, dict)
         self.assertIn('hp_values', data)
+        self.assertIn('status_effects', data['hp_values']['player'][0])
+        self.assertIn('status_effects', data['hp_values']['enemy'][0])
         self.assertIn('log', data)
         self.assertIn('finished', data)
 
@@ -45,6 +47,8 @@ class BattleViewJsonTests(unittest.TestCase):
         data = resp.get_json()
         self.assertIsInstance(data, dict)
         self.assertIn('hp_values', data)
+        self.assertIn('status_effects', data['hp_values']['enemy'][0])
+        self.assertIn('status_effects', data['hp_values']['player'][0])
         self.assertIn('log', data)
         self.assertIn('finished', data)
 


### PR DESCRIPTION
## Summary
- add status effect detail to battle JSON responses
- show monster statuses in battle_turn UI
- include status info in enemy detail panel
- update JS to handle status effect data
- test that battle JSON endpoints include status_effects

## Testing
- `cd backend && make test`

------
https://chatgpt.com/codex/tasks/task_e_6858ba30f2e08321a08f6e02cd0a3a5d