### PR TITLE
Add heal popup indicator

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.css
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.css
@@ -198,6 +198,23 @@ button:hover { background: #004cd1; }
     opacity: 1;
 }
 
+/* === 回復ポップアップ === */
+.heal-indicator {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    color: #32cd32;
+    font-weight: bold;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(0);
+    transition: transform 0.6s ease-out, opacity 0.6s ease-out;
+}
+.heal-indicator.visible {
+    transform: translateY(-40px);
+    opacity: 1;
+}
+
 /* --- Skill selection UI --- */
 #skill-ui { display: none; margin-top: .5rem; }
 .skill-tabs { display: flex; border-bottom: 1px solid #555; margin-bottom: .5rem; }

--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -176,7 +176,9 @@ function updateUnitList(units, infoList) {
         if (mpText) mpText.textContent = info.mp + '/' + info.max_mp;
 
         if (!isNaN(prevHp) && info.hp < prevHp) {
-            showDamageIndicator(unit, '-' + (prevHp - info.hp));
+            showPopupIndicator(unit, '-' + (prevHp - info.hp), 'damage-indicator');
+        } else if (!isNaN(prevHp) && info.hp > prevHp) {
+            showPopupIndicator(unit, '+' + (info.hp - prevHp), 'heal-indicator');
         }
     });
 }
@@ -332,9 +334,9 @@ function applyBattleData(data) {
     // if (cmdWindow) cmdWindow.scrollIntoView({behavior: 'smooth'});
 }
 
-function showDamageIndicator(container, text) {
+function showPopupIndicator(container, text, className) {
     const popup = document.createElement('div');
-    popup.className = 'damage-indicator';
+    popup.className = className;
     popup.textContent = text;
     container.appendChild(popup);
 


### PR DESCRIPTION
## Summary
- add `.heal-indicator` styles for healing popup
- generalize damage popup helper to `showPopupIndicator`
- display healing popup when HP increases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bb6c17888321b25e69f559901159