### PR TITLE
Implement unified party management screen

### DIFF
--- a/backend/src/monster_rpg/static/party/party_manage.js
+++ b/backend/src/monster_rpg/static/party/party_manage.js
@@ -1,0 +1,268 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('monster-detail-modal');
+  const modalBody = document.getElementById('modal-card-body');
+
+  let equipmentList = [];
+  let equipUrl = '';
+  const dataElem = document.getElementById('party-data');
+  if (dataElem) {
+    try {
+      const parsed = JSON.parse(dataElem.textContent);
+      equipmentList = parsed.equipment_list || [];
+      equipUrl = parsed.equip_url || '';
+    } catch (e) {
+      console.error('Failed to parse party-data', e);
+    }
+  }
+
+  function displayMonsterDetails(data) {
+    modalBody.textContent = '';
+    const expNeeded = data.exp_to_next - data.exp;
+    const imgArea = document.createElement('div');
+    imgArea.className = 'card-image-area';
+    const img = document.createElement('img');
+    img.src = data.image;
+    img.alt = data.name;
+    img.className = 'card-monster-img';
+    imgArea.appendChild(img);
+    modalBody.appendChild(imgArea);
+
+    const header = document.createElement('div');
+    header.className = 'card-header';
+    const h2 = document.createElement('h2');
+    h2.id = 'modal-title';
+    h2.className = 'card-monster-name';
+    h2.textContent = data.name;
+    header.appendChild(h2);
+    const lvhp = document.createElement('div');
+    lvhp.className = 'card-monster-lvhp';
+    const spanLv = document.createElement('span');
+    spanLv.textContent = 'Lv. ' + data.level;
+    const spanHp = document.createElement('span');
+    spanHp.textContent = 'HP: ' + data.hp + ' / ' + data.max_hp;
+    const spanExp = document.createElement('span');
+    spanExp.textContent = 'EXP: ' + data.exp + ' / ' + data.exp_to_next + ' (残り ' + expNeeded + ')';
+    lvhp.append(spanLv, document.createTextNode(' | '), spanHp, document.createTextNode(' | '), spanExp);
+    header.appendChild(lvhp);
+    modalBody.appendChild(header);
+
+    const content = document.createElement('div');
+    content.className = 'card-content';
+    const statsGrid = document.createElement('div');
+    statsGrid.className = 'card-stats-grid';
+    const atkSpan = document.createElement('span');
+    atkSpan.textContent = 'こうげき: ';
+    const atkVal = document.createElement('strong');
+    atkVal.textContent = data.stats.attack;
+    atkSpan.appendChild(atkVal);
+    statsGrid.appendChild(atkSpan);
+    const defSpan = document.createElement('span');
+    defSpan.textContent = 'ぼうぎょ: ';
+    const defVal = document.createElement('strong');
+    defVal.textContent = data.stats.defense;
+    defSpan.appendChild(defVal);
+    statsGrid.appendChild(defSpan);
+    const spdSpan = document.createElement('span');
+    spdSpan.textContent = 'すばやさ: ';
+    const spdVal = document.createElement('strong');
+    spdVal.textContent = data.stats.speed;
+    spdSpan.appendChild(spdVal);
+    statsGrid.appendChild(spdSpan);
+    content.appendChild(statsGrid);
+
+    const skillsSection = document.createElement('div');
+    skillsSection.className = 'card-section card-skills-list';
+    const skillsHeader = document.createElement('h3');
+    skillsHeader.textContent = 'スキル';
+    skillsSection.appendChild(skillsHeader);
+    if (data.skills && data.skills.length > 0) {
+      const ul = document.createElement('ul');
+      data.skills.forEach(skill => {
+        const li = document.createElement('li');
+        const strong = document.createElement('strong');
+        strong.textContent = skill.name;
+        li.appendChild(strong);
+        li.appendChild(document.createTextNode(': ' + skill.description));
+        ul.appendChild(li);
+      });
+      skillsSection.appendChild(ul);
+    } else {
+      const p = document.createElement('p');
+      p.textContent = '覚えているスキルはない。';
+      skillsSection.appendChild(p);
+    }
+    content.appendChild(skillsSection);
+
+    const descSection = document.createElement('div');
+    descSection.className = 'card-section card-description';
+    descSection.style.marginTop = '16px';
+    const descHeader = document.createElement('h3');
+    descHeader.textContent = '説明';
+    const descP = document.createElement('p');
+    descP.textContent = data.description;
+    descSection.append(descHeader, descP);
+    content.appendChild(descSection);
+
+    if (data.index !== undefined && data.index >= 0) {
+      const equipSection = document.createElement('div');
+      equipSection.className = 'card-section card-equipment-list';
+      equipSection.style.marginTop = '16px';
+      const equipHeader = document.createElement('h3');
+      equipHeader.textContent = '装備中';
+      equipSection.appendChild(equipHeader);
+
+    const equippedUl = document.createElement('ul');
+    (data.equipment_slots || []).forEach(slot => {
+      const li = document.createElement('li');
+      const name = data.equipment && data.equipment[slot] ? data.equipment[slot] : '空き';
+      li.textContent = slot + ': ' + name;
+      if (data.equipment && data.equipment[slot]) {
+        const btn = document.createElement('button');
+        btn.className = 'unequip-btn';
+        btn.dataset.slot = slot;
+        btn.dataset.idx = data.index;
+        btn.textContent = '外す';
+        li.appendChild(document.createTextNode(' '));
+        li.appendChild(btn);
+      }
+      equippedUl.appendChild(li);
+    });
+    equipSection.appendChild(equippedUl);
+
+    const equipHeader2 = document.createElement('h3');
+    equipHeader2.textContent = '装備する';
+    equipSection.appendChild(equipHeader2);
+
+    if (equipmentList.length > 0) {
+      const invUl = document.createElement('ul');
+      equipmentList.forEach(eq => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.className = 'equip-btn';
+        btn.dataset.equipId = eq.id;
+        btn.dataset.idx = data.index;
+        btn.textContent = '装備';
+        li.textContent = eq.name + ' ';
+        li.appendChild(btn);
+        invUl.appendChild(li);
+      });
+      equipSection.appendChild(invUl);
+    } else {
+      const p = document.createElement('p');
+      p.textContent = '装備を持っていない。';
+      equipSection.appendChild(p);
+      }
+
+      content.appendChild(equipSection);
+    }
+    modalBody.appendChild(content);
+    modal.classList.add('show');
+    modal.focus();
+
+    modalBody.querySelectorAll('.equip-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        btn.disabled = true;
+        const equipId = btn.dataset.equipId;
+        const idx = btn.dataset.idx;
+        fetch(equipUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ equip_id: equipId, monster_idx: idx })
+        })
+        .then(res => res.json())
+        .then(resp => {
+          if (resp.success) {
+            equipmentList.length = 0;
+            resp.equipment_inventory.forEach(e => equipmentList.push(e));
+            data.equipment = resp.monster_equipment;
+            if (resp.monster_stats) data.stats = resp.monster_stats;
+            displayMonsterDetails(data);
+          }
+        })
+        .catch(() => alert('装備の更新に失敗しました'))
+        .finally(() => { btn.disabled = false; });
+      });
+    });
+
+    modalBody.querySelectorAll('.unequip-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        btn.disabled = true;
+        const idx = btn.dataset.idx;
+        const slot = btn.dataset.slot;
+        fetch(equipUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ equip_id: null, monster_idx: idx, slot: slot })
+        })
+        .then(res => res.json())
+        .then(resp => {
+          if (resp.success) {
+            equipmentList.length = 0;
+            resp.equipment_inventory.forEach(e => equipmentList.push(e));
+            data.equipment = resp.monster_equipment;
+            if (resp.monster_stats) data.stats = resp.monster_stats;
+            displayMonsterDetails(data);
+          }
+        })
+        .catch(() => alert('装備の更新に失敗しました'))
+        .finally(() => { btn.disabled = false; });
+      });
+    });
+  }
+
+  function closeModal() { modal.classList.remove('show'); }
+  modal.querySelector('.modal-close-btn').addEventListener('click', closeModal);
+  modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
+  modal.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+
+  document.querySelectorAll('.monster-item').forEach(item => {
+    item.addEventListener('click', () => {
+      const data = JSON.parse(item.dataset.details);
+      displayMonsterDetails(data);
+    });
+  });
+
+  // drag and drop
+  const dropAreas = document.querySelectorAll('.drop-area');
+  let draggedItem = null;
+
+  document.querySelectorAll('.monster-item').forEach(draggable => {
+    draggable.addEventListener('dragstart', e => {
+      draggedItem = e.target;
+      setTimeout(() => draggedItem.classList.add('dragging'), 0);
+    });
+    draggable.addEventListener('dragend', () => {
+      if (draggedItem) draggedItem.classList.remove('dragging');
+      draggedItem = null;
+    });
+  });
+
+  dropAreas.forEach(area => {
+    area.addEventListener('dragover', e => { e.preventDefault(); area.classList.add('drag-over'); });
+    area.addEventListener('dragleave', () => area.classList.remove('drag-over'));
+    area.addEventListener('drop', e => {
+      e.preventDefault();
+      area.classList.remove('drag-over');
+      if (!draggedItem) return;
+      const existing = area.querySelector('.monster-item');
+      if (existing && existing !== draggedItem) {
+        draggedItem.parentElement.appendChild(existing);
+      }
+      area.appendChild(draggedItem);
+    });
+  });
+
+  const confirmBtn = document.getElementById('confirm-btn');
+  if (confirmBtn) {
+    confirmBtn.addEventListener('click', e => {
+      e.preventDefault();
+      const order = [];
+      document.querySelectorAll('.team-slots .monster-item').forEach(el => order.push(el.dataset.uid));
+      const reserve = [];
+      document.querySelectorAll('#monster-pool .monster-item').forEach(el => reserve.push(el.dataset.uid));
+      document.getElementById('order-input').value = JSON.stringify(order);
+      document.getElementById('reserve-input').value = JSON.stringify(reserve);
+      document.getElementById('formation-form').submit();
+    });
+  }
+});

--- a/backend/src/monster_rpg/templates/party_manage.html
+++ b/backend/src/monster_rpg/templates/party_manage.html
@@ -1,0 +1,89 @@
+{% extends "layout.html" %}
+{% block head_extra %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='party/formation.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='party/party.css') }}">
+{% endblock %}
+{% block content %}
+<div class="container">
+  <header>
+    <h1>幻獣の魔導書</h1>
+    <p>汝の最も恐るべき幻獣の部隊を編成せよ。</p>
+  </header>
+  <div class="main-grid">
+    <aside class="sidebar">
+      <div class="book-page">
+        <form id="formation-form" method="post" action="{{ url_for('party.manage', user_id=user_id) }}">
+          <input type="hidden" name="order" id="order-input">
+          <input type="hidden" name="reserve" id="reserve-input">
+          <button id="confirm-btn" type="button" class="ornate-button">編成を確定</button>
+          <button type="submit" name="reset" value="1" class="ornate-button">再編成</button>
+        </form>
+        <h2 style="margin-top: 20px;">部隊の状態</h2>
+        <div style="font-style: italic; color: #666;">
+          <p>汝の部隊の総合力がここに表示されるであろう。</p>
+        </div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <section class="book-page">
+        <h2>召喚陣 (汝の部隊)</h2>
+        <div class="team-slots">
+          {% for entry in party_info %}
+          <div id="slot-{{ loop.index }}" class="drop-area" data-slot="true">
+            <div class="monster-item" data-uid="{{ entry.uid }}" data-details='{{ entry.detail | tojson | forceescape }}' draggable="true">
+              {% if entry.monster.image_filename %}
+              <img src="{{ url_for('static', filename='images/' + entry.monster.image_filename) }}" alt="{{ entry.monster.name }}">
+              {% else %}
+              {{ entry.monster.name }}
+              {% endif %}
+            </div>
+          </div>
+          {% endfor %}
+          {% for i in range(party_info|length + 1, 4) %}
+          <div id="slot-{{ i }}" class="drop-area" data-slot="true">
+            <div class="monster-placeholder">スロット {{ i }}</div>
+          </div>
+          {% endfor %}
+        </div>
+      </section>
+      <section class="book-page">
+        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px;">
+          <h2>待機中の幻獣 (ストック)</h2>
+        </div>
+        <div id="monster-pool" class="drop-area">
+          <div class="monster-grid">
+            {% for entry in reserve_info %}
+            <div id="monster-{{ entry.uid }}" class="monster-item" data-uid="{{ entry.uid }}" data-details='{{ entry.detail | tojson | forceescape }}' draggable="true">
+              {% if entry.monster.image_filename %}
+              <img alt="{{ entry.monster.name }}" src="{{ url_for('static', filename='images/' + entry.monster.image_filename) }}">
+              {% else %}
+              <span class="monster-placeholder">{{ entry.monster.name }}</span>
+              {% endif %}
+            </div>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+    <footer>
+      <p>© 2023 幻獣の魔導書. All rights reserved.</p>
+    </footer>
+    <a class="book-link" href="{{ url_for('play', user_id=user_id) }}">← 戻る</a>
+  </div>
+<div id="monster-detail-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title" tabindex="-1">
+  <div class="modal-card">
+    <button class="modal-close-btn" aria-label="閉じる">&times;</button>
+    <div id="modal-card-body"></div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+  <script id="party-data" type="application/json">
+    {{ {
+        'equipment_list': equipment_list,
+        'equip_url': url_for('party.equip', user_id=user_id)
+    } | tojson | safe }}
+  </script>
+  <script src="{{ url_for('static', filename='party/party_manage.js') }}"></script>
+{% endblock %}

--- a/backend/src/monster_rpg/web/__init__.py
+++ b/backend/src/monster_rpg/web/__init__.py
@@ -41,6 +41,7 @@ def create_app():
         'party': 'party.party',
         'equip': 'party.equip',
         'formation': 'party.formation',
+        'party_manage': 'party.manage',
         'items': 'inventory.items',
         'synthesize': 'inventory.synthesize',
         'synthesize_action': 'inventory.synthesize_action',

--- a/backend/src/monster_rpg/web/party.py
+++ b/backend/src/monster_rpg/web/party.py
@@ -151,3 +151,77 @@ def formation(user_id):
             reserve_info.append(info)
 
     return render_template('formation.html', party_info=party_info, reserve_info=reserve_info, user_id=user_id)
+
+
+@party_bp.route('/manage/<int:user_id>', methods=['GET', 'POST'], endpoint='manage')
+def manage(user_id):
+    """Unified party view with drag-and-drop editing."""
+    player = save_manager.load_game(database_setup.DATABASE_NAME, user_id=user_id)
+    if not player:
+        return redirect(url_for('auth.index'))
+
+    if request.method == 'POST':
+        if 'reset' in request.form:
+            player.reset_formation()
+        elif request.form.get('order'):
+            try:
+                order_uids = json.loads(request.form.get('order'))
+                reserve_uids = json.loads(request.form.get('reserve', '[]'))
+            except json.JSONDecodeError:
+                order_uids, reserve_uids = [], []
+            all_monsters = player.party_monsters + player.reserve_monsters
+            uid_map = {str(i): m for i, m in enumerate(all_monsters)}
+            new_party = [uid_map[str(uid)] for uid in order_uids if str(uid) in uid_map]
+            new_reserve = [uid_map[str(uid)] for uid in reserve_uids if str(uid) in uid_map]
+            used = set(str(u) for u in order_uids + reserve_uids)
+            for i, m in enumerate(all_monsters):
+                if str(i) not in used:
+                    new_reserve.append(m)
+            if new_party:
+                player.party_monsters = new_party
+                player.reserve_monsters = new_reserve
+        save_manager.save_game(player, database_setup.DATABASE_NAME, user_id=user_id)
+
+    all_monsters = player.party_monsters + player.reserve_monsters
+    party_info = []
+    reserve_info = []
+    for uid, m in enumerate(all_monsters):
+        detail = {
+            'name': m.name,
+            'level': m.level,
+            'hp': m.hp,
+            'max_hp': m.max_hp,
+            'exp': m.exp,
+            'exp_to_next': m.calculate_exp_to_next_level(),
+            'image': url_for('static', filename='images/' + m.image_filename) if m.image_filename else '',
+            'stats': {
+                'attack': m.total_attack(),
+                'defense': m.total_defense(),
+                'speed': m.total_speed(),
+            },
+            'skills': m.get_skill_details(),
+            'description': MONSTER_BOOK_DATA.get(m.monster_id).description if MONSTER_BOOK_DATA.get(m.monster_id) else 'このモンスターに関する詳しい説明はまだ見つかっていない。',
+        }
+        if uid < len(player.party_monsters):
+            detail.update({
+                'index': uid,
+                'equipment': {slot: eq.name for slot, eq in m.equipment.items()},
+                'equipment_slots': m.equipment_slots,
+            })
+            party_info.append({'monster': m, 'detail': detail, 'uid': uid})
+        else:
+            reserve_info.append({'monster': m, 'detail': detail, 'uid': uid})
+
+    equipment_list = [
+        {
+            'id': (e.instance_id if isinstance(e, EquipmentInstance) else getattr(e, 'equip_id', str(e))),
+            'name': getattr(e, 'name', ''),
+            'slot': getattr(e, 'slot', ''),
+            'attack': getattr(e, 'total_attack', getattr(e, 'attack', 0)),
+            'defense': getattr(e, 'total_defense', getattr(e, 'defense', 0)),
+        }
+        for e in player.equipment_inventory
+    ]
+
+    return render_template('party_manage.html', party_info=party_info, reserve_info=reserve_info,
+                           user_id=user_id, equipment_list=equipment_list)


### PR DESCRIPTION
## Summary
- add combined party formation view template
- allow drag-and-drop editing with equipment management
- expose new `/manage/<user_id>` route and alias

## Testing
- `cd backend && make test`

------
https://chatgpt.com/codex/tasks/task_e_6858bd0b65a48321944b61eb46aa2c41