### PR TITLE
Implement equipment stat tiers

### DIFF
--- a/backend/src/monster_rpg/items/equipment.py
+++ b/backend/src/monster_rpg/items/equipment.py
@@ -107,6 +107,19 @@ class EquipmentInstance:
         return total
 
 
+def _choose_amount(entry: Dict[str, Any]) -> int:
+    """Return a stat amount using tiers if provided."""
+    if "tiers" in entry:
+        tier_weighted = []
+        for tier in entry["tiers"]:
+            tier_weighted.extend([tier] * tier.get("weight", 1))
+        tier_choice = random.choice(tier_weighted)
+        if "amount" in tier_choice:
+            return tier_choice["amount"]
+        return random.randint(tier_choice.get("min", 1), tier_choice.get("max", 1))
+    return random.randint(entry.get("min", 1), entry.get("max", 1))
+
+
 def _generate_random_bonuses(category: str) -> Dict[str, Any]:
     pools = RANDOM_STAT_CONFIG.get("random_stat_pools_by_category", {}).get(category, {})
     result: Dict[str, Any] = {}
@@ -116,7 +129,7 @@ def _generate_random_bonuses(category: str) -> Dict[str, Any]:
         for entry in main_pool:
             weighted.extend([entry] * entry.get("weight", 1))
         choice = random.choice(weighted)
-        amount = random.randint(choice.get("min", 1), choice.get("max", 1))
+        amount = _choose_amount(choice)
         result["main_stat"] = {"stat": choice["stat"], "amount": amount}
     sub_pool = pools.get("sub_stat_pool", [])
     if sub_pool:
@@ -132,7 +145,7 @@ def _generate_random_bonuses(category: str) -> Dict[str, Any]:
             if entry["stat"] in stats_used:
                 weighted = [e for e in weighted if e["stat"] != entry["stat"]]
                 continue
-            amount = random.randint(entry.get("min", 1), entry.get("max", 1))
+            amount = _choose_amount(entry)
             chosen_stats.append({"stat": entry["stat"], "amount": amount})
             stats_used.add(entry["stat"])
             weighted = [e for e in weighted if e["stat"] != entry["stat"]]

--- a/backend/src/monster_rpg/items/equipment_random_stats.json
+++ b/backend/src/monster_rpg/items/equipment_random_stats.json
@@ -2,21 +2,75 @@
   "random_stat_pools_by_category": {
     "weapon": {
       "main_stat_pool": [
-        {"stat": "attack", "weight": 1, "min": 1, "max": 3}
+        {
+          "stat": "attack",
+          "weight": 1,
+          "tiers": [
+            {"weight": 50, "amount": 10},
+            {"weight": 30, "amount": 13},
+            {"weight": 15, "amount": 16},
+            {"weight": 5,  "amount": 20}
+          ]
+        }
       ],
       "sub_stat_pool": [
-        {"stat": "defense", "weight": 1, "min": 1, "max": 2},
-        {"stat": "speed", "weight": 1, "min": 1, "max": 2}
+        {
+          "stat": "defense",
+          "weight": 1,
+          "tiers": [
+            {"weight": 50, "amount": 10},
+            {"weight": 30, "amount": 13},
+            {"weight": 15, "amount": 16},
+            {"weight": 5,  "amount": 20}
+          ]
+        },
+        {
+          "stat": "speed",
+          "weight": 1,
+          "tiers": [
+            {"weight": 50, "amount": 2},
+            {"weight": 30, "amount": 3},
+            {"weight": 15, "amount": 4},
+            {"weight": 5,  "amount": 5}
+          ]
+        }
       ],
       "sub_stat_count": {"initial_min": 1, "initial_max": 2}
     },
     "armor": {
       "main_stat_pool": [
-        {"stat": "defense", "weight": 1, "min": 1, "max": 3}
+        {
+          "stat": "defense",
+          "weight": 1,
+          "tiers": [
+            {"weight": 50, "amount": 10},
+            {"weight": 30, "amount": 13},
+            {"weight": 15, "amount": 16},
+            {"weight": 5,  "amount": 20}
+          ]
+        }
       ],
       "sub_stat_pool": [
-        {"stat": "attack", "weight": 1, "min": 1, "max": 2},
-        {"stat": "speed", "weight": 1, "min": 1, "max": 2}
+        {
+          "stat": "attack",
+          "weight": 1,
+          "tiers": [
+            {"weight": 50, "amount": 10},
+            {"weight": 30, "amount": 13},
+            {"weight": 15, "amount": 16},
+            {"weight": 5,  "amount": 20}
+          ]
+        },
+        {
+          "stat": "speed",
+          "weight": 1,
+          "tiers": [
+            {"weight": 50, "amount": 2},
+            {"weight": 30, "amount": 3},
+            {"weight": 15, "amount": 4},
+            {"weight": 5,  "amount": 5}
+          ]
+        }
       ],
       "sub_stat_count": {"initial_min": 1, "initial_max": 2}
     }


### PR DESCRIPTION
## Summary
- support tiered stat amounts for equipment bonuses
- add tier values in equipment_random_stats.json

## Testing
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858fce684d08321ba5570ca900f5fe2