### PR TITLE
Implement equipment limit break with generic materials

### DIFF
--- a/backend/src/monster_rpg/database_setup.py
+++ b/backend/src/monster_rpg/database_setup.py
@@ -103,7 +103,10 @@ def initialize_database():
         equip_id TEXT,
         title_id TEXT,
         instance_id TEXT,
-        random_bonuses TEXT
+        random_bonuses TEXT,
+        synthesis_rank INTEGER DEFAULT 0,
+        stat_multiplier REAL DEFAULT 1.0,
+        sub_stat_slots INTEGER DEFAULT 0
     )
     """)
 
@@ -146,6 +149,9 @@ def initialize_database():
         _add_column_if_missing(table, "mp", "INTEGER")
         _add_column_if_missing(table, "max_mp", "INTEGER")
     _add_column_if_missing("player_equipment", "random_bonuses", "TEXT")
+    _add_column_if_missing("player_equipment", "synthesis_rank", "INTEGER")
+    _add_column_if_missing("player_equipment", "stat_multiplier", "REAL")
+    _add_column_if_missing("player_equipment", "sub_stat_slots", "INTEGER")
 
     # exploration_progress テーブルの作成
     cursor.execute(

--- a/backend/src/monster_rpg/items/equipment.py
+++ b/backend/src/monster_rpg/items/equipment.py
@@ -23,6 +23,7 @@ class Equipment:
     name: str
     slot: str
     category: str
+    rarity: str = "common"
     attack: int = 0
     defense: int = 0
 
@@ -32,6 +33,7 @@ BRONZE_SWORD = Equipment(
     "ブロンズソード",
     slot="weapon",
     category="weapon",
+    rarity="common",
     attack=3,
 )
 LEATHER_ARMOR = Equipment(
@@ -39,6 +41,7 @@ LEATHER_ARMOR = Equipment(
     "レザーアーマー",
     slot="armor",
     category="armor",
+    rarity="common",
     defense=2,
 )
 
@@ -55,6 +58,9 @@ class EquipmentInstance:
     title: Title | None
     random_bonuses: Dict[str, Any] = field(default_factory=dict)
     instance_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    synthesis_rank: int = 0
+    stat_multiplier: float = 1.0
+    sub_stat_slots: int = 0
 
     @property
     def name(self) -> str:
@@ -70,13 +76,15 @@ class EquipmentInstance:
     def total_attack(self) -> int:
         bonus = self.title.stat_bonuses.get("attack", 0) if self.title else 0
         bonus += self._bonus_for("attack")
-        return self.base_item.attack + bonus
+        base = int(self.base_item.attack * self.stat_multiplier)
+        return base + bonus
 
     @property
     def total_defense(self) -> int:
         bonus = self.title.stat_bonuses.get("defense", 0) if self.title else 0
         bonus += self._bonus_for("defense")
-        return self.base_item.defense + bonus
+        base = int(self.base_item.defense * self.stat_multiplier)
+        return base + bonus
 
     @property
     def total_speed(self) -> int:

--- a/backend/src/monster_rpg/items/equipment_synthesis.py
+++ b/backend/src/monster_rpg/items/equipment_synthesis.py
@@ -1,0 +1,20 @@
+import json
+import os
+from typing import Dict, Any
+
+
+def load_rules(filepath: str | None = None) -> Dict[str, Any]:
+    if filepath is None:
+        filepath = os.path.join(os.path.dirname(__file__), "equipment_synthesis_rules.json")
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            text = f.read()
+    except FileNotFoundError as e:
+        raise ValueError(f"Rules file not found: {filepath}") from e
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in {filepath}") from e
+
+
+EQUIPMENT_SYNTHESIS_RULES: Dict[str, Any] = load_rules()

--- a/backend/src/monster_rpg/items/equipment_synthesis_rules.json
+++ b/backend/src/monster_rpg/items/equipment_synthesis_rules.json
@@ -1,0 +1,12 @@
+{
+  "weapon": [
+    { "rank": 1, "cost": [{ "item_id": "weapon_core_common", "amount": 5 }], "bonus_type": "base_stats_multiplier", "value": 1.05, "description": "基礎性能+5%" },
+    { "rank": 2, "cost": [{ "item_id": "weapon_core_common", "amount": 15 }], "bonus_type": "base_stats_multiplier", "value": 1.12, "description": "基礎性能+12%" },
+    { "rank": 3, "cost": [{ "item_id": "weapon_core_rare", "amount": 10 }], "bonus_type": "add_sub_stat_slot", "value": 1, "description": "サブステータス最大数+1" }
+  ],
+  "armor": [
+    { "rank": 1, "cost": [{ "item_id": "armor_fragment_common", "amount": 5 }], "bonus_type": "base_stats_multiplier", "value": 1.05, "description": "基礎性能+5%" },
+    { "rank": 2, "cost": [{ "item_id": "armor_fragment_common", "amount": 15 }], "bonus_type": "base_stats_multiplier", "value": 1.12, "description": "基礎性能+12%" },
+    { "rank": 3, "cost": [{ "item_id": "armor_fragment_rare", "amount": 10 }], "bonus_type": "add_sub_stat_slot", "value": 1, "description": "サブステータス最大数+1" }
+  ]
+}

--- a/backend/src/monster_rpg/items/items.json
+++ b/backend/src/monster_rpg/items/items.json
@@ -67,5 +67,21 @@
   "frost_crystal": {
     "name": "フロストクリスタル",
     "description": "極寒地で採れる冷気を封じ込めた氷晶。"
+  },
+  "weapon_core_common": {
+    "name": "下級・武器の核",
+    "description": "武器強化に使われる基本的な素材。"
+  },
+  "weapon_core_rare": {
+    "name": "上級・武器の核",
+    "description": "高品質な武器強化素材。"
+  },
+  "armor_fragment_common": {
+    "name": "下級・防具の欠片",
+    "description": "防具強化に使われる基本的な素材。"
+  },
+  "armor_fragment_rare": {
+    "name": "上級・防具の欠片",
+    "description": "高品質な防具強化素材。"
   }
 }

--- a/backend/src/monster_rpg/player.py
+++ b/backend/src/monster_rpg/player.py
@@ -102,6 +102,12 @@ class Player:
     def equip_to_monster(self, party_idx: int, equip_id: str | None = None, slot: str | None = None) -> bool:
         return party_manager.equip_to_monster(self, party_idx, equip_id, slot)
 
+    def disassemble_equipment(self, equip_id: str) -> bool:
+        return party_manager.disassemble_equipment(self, equip_id)
+
+    def limit_break_equipment(self, equip_id: str) -> bool:
+        return party_manager.limit_break_equipment(self, equip_id)
+
     # --- Synthesis -------------------------------------------------------
     def synthesize_monster(self, monster1_idx: int, monster2_idx: int, item_id: str | None = None):
         return synthesis_manager.synthesize_monster(self, monster1_idx, monster2_idx, item_id)

--- a/backend/tests/test_equipment_synthesis.py
+++ b/backend/tests/test_equipment_synthesis.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+from monster_rpg import database_setup
+from monster_rpg.player import Player
+from monster_rpg import save_manager
+from monster_rpg.items.equipment import EquipmentInstance, BRONZE_SWORD
+from monster_rpg.items.item_data import ALL_ITEMS
+
+
+class EquipmentSynthesisTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_synth.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        database_setup.DATABASE_NAME = self.db_path
+        database_setup.initialize_database()
+        self.user_id = database_setup.create_user('synth', 'pw')
+
+    def tearDown(self):
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_disassemble_equipment_gives_material(self):
+        player = Player('Tester', user_id=self.user_id)
+        equip = EquipmentInstance(base_item=BRONZE_SWORD, title=None)
+        player.equipment_inventory.append(equip)
+        success = player.disassemble_equipment(equip.instance_id)
+        self.assertTrue(success)
+        self.assertEqual(len(player.equipment_inventory), 0)
+        self.assertEqual(len(player.items), 1)
+        self.assertEqual(player.items[0].item_id, 'weapon_core_common')
+
+    def test_limit_break_persists(self):
+        player = Player('Tester', user_id=self.user_id)
+        equip = EquipmentInstance(base_item=BRONZE_SWORD, title=None)
+        player.equipment_inventory.append(equip)
+        player.items.extend([ALL_ITEMS['weapon_core_common'] for _ in range(5)])
+        self.assertTrue(player.limit_break_equipment(equip.instance_id))
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
+        self.assertEqual(loaded.equipment_inventory[0].synthesis_rank, 1)
+        self.assertGreater(loaded.equipment_inventory[0].stat_multiplier, 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_save_load.py
+++ b/backend/tests/test_save_load.py
@@ -69,7 +69,8 @@ class SaveLoadTests(unittest.TestCase):
 
         loaded = save_manager.load_game(self.db_path, user_id=self.user1)
         self.assertEqual(len(loaded.equipment_inventory), 1)
-        self.assertEqual(loaded.equipment_inventory[0].equip_id, 'bronze_sword')
+        equip = loaded.equipment_inventory[0]
+        self.assertEqual(equip.base_item.equip_id, 'bronze_sword')
 
     def test_hp_mp_persist(self):
         player = Player('HPTester', user_id=self.user1)


### PR DESCRIPTION
## Summary
- add generic material items used for equipment synthesis
- support equipment limit break rules in JSON
- expand Equipment and EquipmentInstance with rarity and limit break data
- implement disassembly and limit break logic
- persist new equipment fields in the database
- expose new player helper methods
- test limit break persistence and equipment disassembly

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685905986a688321bdfe24c0f06bbf60