### PR TITLE
Update battle turn page with new UI

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_page.css
+++ b/backend/src/monster_rpg/static/battle_turn/battle_page.css
@@ -1,0 +1,34 @@
+.battle-page {
+    max-width: 960px;
+    margin: 1rem auto;
+    padding: 1rem;
+    background: #f8f0c0;
+    border: 1px solid #d8caa0;
+    border-radius: 8px;
+}
+.turn-order-bar {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+.party-area {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+.command-tabs {
+    margin-top: 1rem;
+}
+.tab-buttons {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.tab-buttons button {
+    padding: 0.3rem 0.6rem;
+}
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+

--- a/backend/src/monster_rpg/templates/battle_turn.html
+++ b/backend/src/monster_rpg/templates/battle_turn.html
@@ -1,137 +1,70 @@
 {% extends "layout.html" %}
 
 {% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='battle_turn/battle_page.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='battle_turn/battle_turn.css') }}">
 {% endblock %}
 
 {% block content %}
-<div class="container-battle">
-    <div class="enemy-area">
-        {% for e in enemy_party %}
-            {% set hp_pct = (e.hp / e.max_hp * 100)|round(0) %}
-            {% set hp_cls = 'hp-fill' %}
-            {% set mp_pct = ((e.mp / e.max_mp * 100) if e.max_mp > 0 else 0)|round(0) %}
-            {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
-            
-            <div class="battle-unit enemy{% if not e.is_alive %} down{% endif %}"
-                 data-down="{{ not e.is_alive }}" data-unit-id="enemy-{{ loop.index0 }}"
-                 data-name="{{ e.name }}" data-level="{{ e.level }}" data-hp="{{ e.hp }}"
-                 data-max-hp="{{ e.max_hp }}" data-mp="{{ e.mp }}" data-max-mp="{{ e.max_mp }}"
-                 data-attack="{{ e.attack }}" data-defense="{{ e.defense }}" data-speed="{{ e.speed }}"
-                 data-statuses="{{ e.status_effects|tojson }}">
-                
-                {% if e.image_filename %}
-                    <img class="unit-img" src="{{ url_for('static', filename='images/' + e.image_filename) }}" alt="{{ e.name }}">
-                {% endif %}
-                <div class="member-info">
-                    <div class="member-name">{{ e.name }}</div>
-                    <div class="hp-bar"><div class="{{ hp_cls }}" style="width:{{ hp_pct }}%"></div></div>
-                    <div class="mp-bar"><div class="mp-fill" style="width:{{ mp_pct }}%"></div></div>
-                </div>
-                <div class="hp-text">{{ e.hp }}/{{ e.max_hp }}</div>
-                <div class="mp-text">{{ e.mp }}/{{ e.max_mp }}</div>
-            </div>
-        {% endfor %}
-    </div>
+<div class="battle-page">
+  <div id="turn-order-bar" class="turn-order-bar"></div>
+  <div id="enemy-party-area" class="party-area"></div>
+  <div id="ally-party-area" class="party-area"></div>
 
-    <hr class="divider">
-
-    <div class="ally-area">
-        <div class="ally-party-display">
-            {% for m in player_party %}
-                {% set hp_pct = (m.hp / m.max_hp * 100)|round(0) %}
-            {% set hp_cls = 'hp-fill' %}
-            {% set mp_pct = ((m.mp / m.max_mp * 100) if m.max_mp > 0 else 0)|round(0) %}
-            {% if hp_pct <= 25 %}{% set hp_cls = hp_cls + ' critical' %}{% elif hp_pct <= 50 %}{% set hp_cls = hp_cls + ' low' %}{% endif %}
-
-                <div class="battle-unit ally{% if not m.is_alive %} down{% endif %}{% if current_actor and m is sameas current_actor %} active-turn{% endif %}"
-                     data-down="{{ not m.is_alive }}" data-unit-id="ally-{{ loop.index0 }}" data-mp="{{ m.mp }}" data-max-mp="{{ m.max_mp }}"
-                     data-statuses="{{ m.status_effects|tojson }}">
-                    
-                    {% if m.image_filename %}
-                        <img class="unit-img" src="{{ url_for('static', filename='images/' + m.image_filename) }}" alt="{{ m.name }}">
-                    {% endif %}
-                    <div class="member-info">
-                        <div class="member-name">{{ m.name }}</div>
-                        <div class="hp-bar"><div class="{{ hp_cls }}" style="width:{{ hp_pct }}%"></div></div>
-                        <div class="mp-bar"><div class="mp-fill" style="width:{{ mp_pct }}%"></div></div>
-                    </div>
-                    <div class="hp-text">{{ m.hp }}/{{ m.max_hp }}</div>
-                    <div class="mp-text">{{ m.mp }}/{{ m.max_mp }}</div>
-                </div>
-            {% endfor %}
+  <div class="command-window">
+    <div class="turn-banner">Turn {{ init_data.turn }}</div>
+    <div class="command-tabs">
+      <div class="tab-buttons">
+        <button data-panel="tab-actions" class="tab-btn active">行動</button>
+        <button data-panel="tab-skills" class="tab-btn">スキル</button>
+        <button data-panel="tab-items" class="tab-btn">アイテム</button>
+        <button data-panel="tab-other" class="tab-btn">その他</button>
+      </div>
+      <div id="tab-actions" class="tab-panel active"></div>
+      <div id="tab-skills" class="tab-panel">
+        <div id="skill-ui">
+          <input type="hidden" name="selected_skill_id" id="selected-skill-id">
+          <div id="skill-tabs" class="skill-tabs"></div>
+          <div id="skill-panels" class="skill-panels"></div>
+          <div id="skill-desc" class="skill-desc"></div>
         </div>
-
-        <div class="command-window">
-            <div class="turn-banner">Turn {{ battle.turn }}</div>
-            {% if current_actor and current_actor in player_party %}
-            <form action="{{ url_for('battle', user_id=user_id) }}" method="post">
-                <div class="action-row">
-                    <label for="action">{{ current_actor.name }}:</label>
-                    <select name="action" id="action">
-                        <option value="attack" data-target="enemy" data-scope="single">攻撃</option>
-                        <option value="skill" data-target="enemy" data-scope="single">スキル</option>
-                        <option value="item" data-target="ally" data-scope="single">アイテム</option>
-                        <option value="scout" data-target="enemy" data-scope="single">スカウト</option>
-                        <option value="run" data-target="none" data-scope="none">逃げる</option>
-                    </select>
-                    <div id="skill-ui">
-                        <input type="hidden" name="selected_skill_id" id="selected-skill-id">
-                        <div id="skill-tabs" class="skill-tabs"></div>
-                        <div id="skill-panels" class="skill-panels"></div>
-                        <div id="skill-desc" class="skill-desc"></div>
-                    </div>
-                    <div>
-                        <select name="target_enemy">
-                            {% for e in enemy_party if e.is_alive %}
-                            <option value="{{ loop.index0 }}">{{ e.name }}</option>
-                            {% endfor %}
-                        </select>
-                        <select name="target_ally">
-                            {% for a in player_party if a.is_alive %}
-                            <option value="{{ loop.index0 }}">{{ a.name }}</option>
-                            {% endfor %}
-                        </select>
-                        <select name="item_idx">
-                            {% for it in player.items %}
-                            <option value="{{ loop.index0 }}">{{ it.name }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                </div>
-                <button type="submit">行動決定</button>
-            </form>
-            {% else %}
-            <div class="turn-banner">敵の行動中...</div>
-            {% endif %}
-        </div>
-
-        <ul class="log">
-            {% for entry in log %}
-            <li class="log-message-{{ entry.type }}">{{ entry.message }}</li>
-            {% endfor %}
-        </ul>
-
-        <a href="{{ url_for('play', user_id=user_id) }}" class="back-link">戻る</a>
+      </div>
+      <div id="tab-items" class="tab-panel"></div>
+      <div id="tab-other" class="tab-panel"></div>
     </div>
 
-    <div class="enemy-detail-panel" id="enemy-detail">
-        <button class="close-btn" type="button">&times;</button>
-        <h3 id="detail-name"></h3>
-        <ul>
-            <li>Lv <span id="detail-level"></span></li>
-            <li>HP <span id="detail-hp"></span>/<span id="detail-max-hp"></span></li>
-            <li>MP <span id="detail-mp"></span>/<span id="detail-max-mp"></span></li>
-            <li>攻撃 <span id="detail-attack"></span></li>
-            <li>防御 <span id="detail-defense"></span></li>
-            <li>素早さ <span id="detail-speed"></span></li>
-            <li>状態 <span id="detail-statuses"></span></li>
-        </ul>
-    </div>
+    <form id="command-form" action="{{ url_for('battle.battle', user_id=user_id) }}" method="post">
+      <select name="action" id="action" hidden></select>
+      <select name="target_enemy" hidden></select>
+      <select name="target_ally" hidden></select>
+      <select name="item_idx" hidden></select>
+      <button type="submit" id="submit-btn">行動決定</button>
+    </form>
+  </div>
+
+  <ul id="battle-log" class="log"></ul>
+  <a href="{{ url_for('play', user_id=user_id) }}" class="back-link">戻る</a>
+</div>
+
+<div class="enemy-detail-panel" id="enemy-detail">
+  <button class="close-btn" type="button">&times;</button>
+  <h3 id="detail-name"></h3>
+  <ul>
+    <li>Lv <span id="detail-level"></span></li>
+    <li>HP <span id="detail-hp"></span>/<span id="detail-max-hp"></span></li>
+    <li>MP <span id="detail-mp"></span>/<span id="detail-max-mp"></span></li>
+    <li>攻撃 <span id="detail-attack"></span></li>
+    <li>防御 <span id="detail-defense"></span></li>
+    <li>素早さ <span id="detail-speed"></span></li>
+    <li>状態 <span id="detail-statuses"></span></li>
+  </ul>
 </div>
 {% endblock %}
 
-
 {% block scripts %}
+<script id="battle-init-data" type="application/json">
+{{ init_data | tojson | safe }}
+</script>
 <script src="{{ url_for('static', filename='battle_turn/battle_turn.js') }}"></script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- redesign battle_turn.html with placeholders for JS
- add parchment-style CSS
- rework battle_turn.js to build UI dynamically
- extend battle routes to provide new JSON fields

## Testing
- `pip install flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0a13e2488321bf5ce67b417a0a34