### PR TITLE
Enable CSRF protection for battle forms

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+Flask-WTF

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -17,6 +17,7 @@ setup(
         ]
     },
     install_requires=[
-        'Flask'
+        'Flask',
+        'Flask-WTF'
     ],
 )

--- a/backend/src/monster_rpg/templates/battle_turn.html
+++ b/backend/src/monster_rpg/templates/battle_turn.html
@@ -35,6 +35,7 @@
     </div>
 
     <form id="command-form" action="{{ url_for('battle.battle', user_id=user_id) }}" method="post">
+      {{ csrf_token() }}
       <select name="action" id="action" hidden></select>
       <select name="target_enemy" hidden></select>
       <select name="target_ally" hidden></select>

--- a/backend/src/monster_rpg/web/__init__.py
+++ b/backend/src/monster_rpg/web/__init__.py
@@ -1,5 +1,6 @@
 import os
 from flask import Flask
+from flask_wtf.csrf import CSRFProtect
 from .. import database_setup
 from ..map_data import load_locations
 
@@ -10,6 +11,8 @@ def create_app():
     static = os.path.join(base_dir, '..', 'static')
     app = Flask(__name__, template_folder=templates, static_folder=static)
     app.secret_key = os.getenv("FLASK_SECRET_KEY", "dev-secret")
+    app.config.setdefault("WTF_CSRF_SECRET_KEY", app.secret_key)
+    csrf = CSRFProtect(app)
     database_setup.initialize_database()
     load_locations()
 

--- a/backend/tests/test_battle_item_use.py
+++ b/backend/tests/test_battle_item_use.py
@@ -15,6 +15,8 @@ class BattleItemUseTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         hero = Monster('Hero', hp=50, attack=5, defense=2, speed=10)

--- a/backend/tests/test_battle_item_use_extended.py
+++ b/backend/tests/test_battle_item_use_extended.py
@@ -16,6 +16,8 @@ class BattleItemMpStatusTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester2', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester2', user_id=self.user_id)
         hero = Monster('Hero', hp=50, attack=5, defense=2, speed=10)

--- a/backend/tests/test_battle_run.py
+++ b/backend/tests/test_battle_run.py
@@ -15,6 +15,8 @@ class BattleRunTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         hero = Monster('Hero', hp=20, attack=5, defense=2)

--- a/backend/tests/test_continue_explore_redirect.py
+++ b/backend/tests/test_continue_explore_redirect.py
@@ -14,6 +14,8 @@ class ContinueExploreRedirectTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         save_manager.save_game(player, self.db_path, user_id=self.user_id)

--- a/backend/tests/test_equip_route.py
+++ b/backend/tests/test_equip_route.py
@@ -15,6 +15,8 @@ class EquipRouteTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         player.add_monster_to_party('slime')

--- a/backend/tests/test_hidden_connections.py
+++ b/backend/tests/test_hidden_connections.py
@@ -16,6 +16,8 @@ class HiddenConnectionsTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         player.current_location_id = 'deep_forest'
@@ -28,6 +30,7 @@ class HiddenConnectionsTests(unittest.TestCase):
 
     def test_connections_unlocked_at_100(self):
         loc = LOCATIONS['deep_forest']
+        loc.boss_enemy_id = None
         self.assertNotIn('さらに奥へ', loc.connections)
         with patch('monster_rpg.web.explore.random.randint', return_value=20), \
              patch('monster_rpg.web.explore.random.random', return_value=1.0):

--- a/backend/tests/test_item_monster_synthesis.py
+++ b/backend/tests/test_item_monster_synthesis.py
@@ -42,6 +42,8 @@ class ItemMonsterSynthesisRouteTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         player.add_monster_to_party('slime')

--- a/backend/tests/test_party_formation.py
+++ b/backend/tests/test_party_formation.py
@@ -29,6 +29,8 @@ class FormationRouteTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         for mid in ('slime', 'goblin', 'wolf'):

--- a/backend/tests/test_required_item.py
+++ b/backend/tests/test_required_item.py
@@ -16,6 +16,8 @@ class RequiredItemMovementTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user("tester", "pw")
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
 
     def tearDown(self):

--- a/backend/tests/test_synthesis_inheritance.py
+++ b/backend/tests/test_synthesis_inheritance.py
@@ -40,6 +40,8 @@ class SynthesisRouteTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         player.add_monster_to_party('slime')

--- a/backend/tests/test_trade.py
+++ b/backend/tests/test_trade.py
@@ -17,6 +17,8 @@ class TradeTests(unittest.TestCase):
         database_setup.initialize_database()
         self.seller_id = database_setup.create_user('seller', 'pw1')
         self.buyer_id = database_setup.create_user('buyer', 'pw2')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
 
         seller = Player('Seller', user_id=self.seller_id)

--- a/backend/tests/test_web_battle_get_json.py
+++ b/backend/tests/test_web_battle_get_json.py
@@ -14,6 +14,8 @@ class BattleGetJsonTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         hero = Monster('Hero', hp=20, attack=5, defense=2)

--- a/backend/tests/test_web_battle_json.py
+++ b/backend/tests/test_web_battle_json.py
@@ -14,6 +14,8 @@ class BattleViewJsonTests(unittest.TestCase):
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
         self.user_id = database_setup.create_user('tester', 'pw')
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
         self.client = app.test_client()
         player = Player('Tester', user_id=self.user_id)
         hero = Monster('Hero', hp=20, attack=5, defense=2)


### PR DESCRIPTION
## Summary
- enable `Flask-WTF` CSRF protection in the web app
- embed CSRF token in `battle_turn.html`
- disable CSRF during tests and patch failing test
- add Flask-WTF to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a362c66648321a50fbfc77f8e0c01