### PR TITLE
Improve fetch error handling

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -362,7 +362,12 @@ function setupBattleUI() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
             })
-                .then(resp => resp.json())
+                .then(resp => {
+                    if (!resp.ok) {
+                        throw new Error(`HTTP ${resp.status}`);
+                    }
+                    return resp.json();
+                })
                 .then(data => {
                     if (data.finished) {
                         document.open();
@@ -374,7 +379,7 @@ function setupBattleUI() {
                 })
                 .catch(err => {
                     console.error('Fetch error', err);
-                    alert('通信エラーが発生しました');
+                    alert(`通信エラー: ${err.message}`);
                 })
                 .finally(() => {
                     if (submitBtn) submitBtn.disabled = false;
@@ -576,9 +581,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const m = form.getAttribute('action').match(/\/battle\/(\d+)/);
         if (m) {
             fetch(`/battle/${m[1]}`)
-                .then(resp => resp.json())
+                .then(resp => {
+                    if (!resp.ok) {
+                        throw new Error(`HTTP ${resp.status}`);
+                    }
+                    return resp.json();
+                })
                 .then(data => applyBattleData(data))
-                .catch(err => console.error('Fetch error', err));
+                .catch(err => {
+                    console.error('Fetch error', err);
+                    alert(`通信エラー: ${err.message}`);
+                });
         }
     }
 });

--- a/backend/tests/test_web_battle_get_json.py
+++ b/backend/tests/test_web_battle_get_json.py
@@ -40,5 +40,13 @@ class BattleGetJsonTests(unittest.TestCase):
         self.assertIn('log', data)
         self.assertIn('finished', data)
 
+    def test_get_returns_404_without_active_battle(self):
+        active_battles.pop(self.user_id, None)
+        resp = self.client.get(f'/battle-json/{self.user_id}')
+        self.assertEqual(resp.status_code, 404)
+        data = resp.get_json()
+        self.assertIsInstance(data, dict)
+        self.assertEqual(data.get('error'), 'no_active_battle')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- throw error if battle fetch has bad HTTP status
- display specific message on fetch error
- cover 404 case in battle-json endpoint tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3e726a748321b7e7ff215dc76f53