### PR TITLE
Update initial battle fetch to use JSON endpoint

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -582,7 +582,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (form) {
         const m = form.getAttribute('action').match(/\/battle\/(\d+)/);
         if (m) {
-            fetch(`/battle/${m[1]}`)
+            // Load the current battle state without advancing the turn
+            fetch(`/battle-json/${m[1]}`)
                 .then(resp => {
                     if (!resp.ok) {
                         throw new Error(`HTTP ${resp.status}`);


### PR DESCRIPTION
## Summary
- fetch battle state from `/battle-json/<user_id>`
- ensure returned JSON populates the battle UI

## Testing
- `pytest backend/tests/test_web_battle_get_json.py -q`
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4d3828c48321882cff89ac09225e