### PR TITLE
Add password input and pass to create_user

### DIFF
--- a/backend/src/monster_rpg/templates/index.html
+++ b/backend/src/monster_rpg/templates/index.html
@@ -5,6 +5,7 @@
   <div class="form-card">
     <form action="{{ url_for('auth.start_game') }}" method="post">
       <input name="username" placeholder="名前" required>
+      <input name="password" type="password" placeholder="パスワード">
       <button type="submit">新規ゲーム</button>
     </form>
   </div>

--- a/backend/src/monster_rpg/web/auth.py
+++ b/backend/src/monster_rpg/web/auth.py
@@ -16,8 +16,9 @@ def index():
 def start_game():
     """Create a new player and start the game."""
     name = request.form.get('username', 'Hero')
+    password = request.form.get('password', 'pw')
     try:
-        user_id = database_setup.create_user(name, 'pw')
+        user_id = database_setup.create_user(name, password)
     except sqlite3.IntegrityError:
         msg = '既に同じ名前の人が存在しています'
         return render_template('result.html', message=msg, user_id=None)


### PR DESCRIPTION
## Summary
- add password input field in the new game form
- read password in `auth.start_game` and pass to database setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5254db9083218591b5e53a2cbf79