### PR TITLE
Add FLASK_DEBUG setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository provides README files in multiple languages:
 - [日本語](backend/README/README_JA.md)
 
 Set the environment variable `MONSTER_RPG_DB` to change where the game saves
-its SQLite database.
+its SQLite database. To enable Flask's debug mode when launching the web
+interface, set `FLASK_DEBUG=true`.
 
 ## Quickstart
 Install the package from the `backend` directory and launch the web interface:

--- a/backend/src/monster_rpg/start_rpg.py
+++ b/backend/src/monster_rpg/start_rpg.py
@@ -1,6 +1,8 @@
 """Convenience script to launch the Monster RPG web interface."""
 
+import os
 from .web_main import app
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() == "true"
+    app.run(debug=debug_mode)

--- a/backend/src/monster_rpg/webapp.py
+++ b/backend/src/monster_rpg/webapp.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify
+import os
 import sqlite3
 from . import database_setup
 from .player import Player
@@ -45,4 +46,5 @@ def load_game(user_id):
     return jsonify({'name': player.name, 'level': player.player_level, 'gold': player.gold})
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() == "true"
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## Summary
- allow enabling Flask debug mode via `FLASK_DEBUG` environment variable
- document the new setting in the main README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b538f45e88321811c2a6676c4e12c