### PR TITLE
Fix equipment sub stat slot tracking

### DIFF
--- a/backend/src/monster_rpg/party_manager.py
+++ b/backend/src/monster_rpg/party_manager.py
@@ -13,6 +13,7 @@ from .items.equipment import (
     create_titled_equipment,
     EquipmentInstance,
     Equipment,
+    _generate_random_sub_stat,
 )
 from .items.equipment_synthesis import EQUIPMENT_SYNTHESIS_RULES
 from typing import TYPE_CHECKING
@@ -282,6 +283,14 @@ def limit_break_equipment(player: "Player", equip_instance_id: str) -> bool:
         equip.stat_multiplier *= float(value)
     elif bonus_type == "add_sub_stat_slot":
         equip.sub_stat_slots += int(value)
+        current = equip.random_bonuses.setdefault("sub_stats", [])
+        used = {s.get("stat") for s in current}
+        while len(current) < equip.sub_stat_slots:
+            bonus = _generate_random_sub_stat(equip.base_item.category, used)
+            if not bonus:
+                break
+            current.append(bonus)
+            used.add(bonus["stat"])
     print(f"{equip.name} がランク{equip.synthesis_rank}になった！")
     return True
 

--- a/backend/tests/test_equipment_synthesis.py
+++ b/backend/tests/test_equipment_synthesis.py
@@ -1,10 +1,15 @@
 import os
 import unittest
+import random
 
 from monster_rpg import database_setup
 from monster_rpg.player import Player
 from monster_rpg import save_manager
-from monster_rpg.items.equipment import EquipmentInstance, BRONZE_SWORD
+from monster_rpg.items.equipment import (
+    EquipmentInstance,
+    BRONZE_SWORD,
+    create_titled_equipment,
+)
 from monster_rpg.items.item_data import ALL_ITEMS
 
 
@@ -41,6 +46,30 @@ class EquipmentSynthesisTests(unittest.TestCase):
         loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
         self.assertEqual(loaded.equipment_inventory[0].synthesis_rank, 1)
         self.assertGreater(loaded.equipment_inventory[0].stat_multiplier, 1.0)
+
+    def test_sub_stat_slots_persist_and_limit(self):
+        random.seed(0)
+        player = Player('Tester', user_id=self.user_id)
+        equip = create_titled_equipment('bronze_sword')
+        player.equipment_inventory.append(equip)
+        initial_slots = len(equip.random_bonuses.get('sub_stats', []))
+        self.assertEqual(equip.sub_stat_slots, initial_slots)
+        player.items.extend([ALL_ITEMS['weapon_core_common'] for _ in range(20)])
+        player.items.extend([ALL_ITEMS['weapon_core_rare'] for _ in range(10)])
+        self.assertTrue(player.limit_break_equipment(equip.instance_id))
+        self.assertTrue(player.limit_break_equipment(equip.instance_id))
+        self.assertTrue(player.limit_break_equipment(equip.instance_id))
+        self.assertLessEqual(
+            len(equip.random_bonuses.get('sub_stats', [])), equip.sub_stat_slots
+        )
+        save_manager.save_game(player, self.db_path, user_id=self.user_id)
+        loaded = save_manager.load_game(self.db_path, user_id=self.user_id)
+        loaded_equip = loaded.equipment_inventory[0]
+        self.assertEqual(loaded_equip.sub_stat_slots, equip.sub_stat_slots)
+        self.assertEqual(
+            len(loaded_equip.random_bonuses.get('sub_stats', [])),
+            len(equip.random_bonuses.get('sub_stats', [])),
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- track available random sub stat slots when creating equipment
- generate random sub stats when limit breaking while respecting slot count
- keep sub stat slots on save/load
- test sub stat slot persistence and capacity limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5ac1a2688321a5cda85b17978757