### PR TITLE
Fix deepcopy of equipment in Monster.copy

### DIFF
--- a/backend/src/monster_rpg/monsters/monster_class.py
+++ b/backend/src/monster_rpg/monsters/monster_class.py
@@ -526,4 +526,6 @@ class Monster:
         new_monster.base_magic = self.base_magic
         new_monster.is_alive = True
         new_monster.skill_sequence = self.skill_sequence[:]
+        new_monster.equipment = copy.deepcopy(self.equipment)
+        new_monster.equipment_slots = self.equipment_slots[:]
         return new_monster


### PR DESCRIPTION
## Summary
- ensure Monster.copy deep copies equipment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5df8cf848321beebc965b5cd056e