### PR TITLE
Implement rank-aware monster family synthesis

### DIFF
--- a/backend/src/monster_rpg/monsters/__init__.py
+++ b/backend/src/monster_rpg/monsters/__init__.py
@@ -15,6 +15,7 @@ from .synthesis_rules import (
     SYNTHESIS_RECIPES,
     SYNTHESIS_ITEMS_REQUIRED,
     MONSTER_ITEM_RECIPES,
+    find_family_synthesis_result,
 )
 from .evolution_rules import EVOLUTION_RULES
 

--- a/backend/src/monster_rpg/monsters/monster_data.py
+++ b/backend/src/monster_rpg/monsters/monster_data.py
@@ -124,6 +124,11 @@ def load_monsters(filepath: str | None = None) -> Tuple[Dict[str, Monster], Dict
     return _load_from_json(filepath)
 
 
+def get_all_monsters() -> Dict[str, Monster]:
+    """Return the dictionary of all loaded monsters."""
+    return ALL_MONSTERS
+
+
 # Load monster data at import time
 ALL_MONSTERS, MONSTER_BOOK_DATA = _load_from_json()
 

--- a/backend/src/monster_rpg/synthesis_manager.py
+++ b/backend/src/monster_rpg/synthesis_manager.py
@@ -13,7 +13,7 @@ from .monsters.synthesis_rules import (
     SYNTHESIS_ITEMS_REQUIRED,
     MONSTER_ITEM_RECIPES,
     ITEM_ITEM_RECIPES,
-    FAMILY_SYNTHESIS_RULES,
+    find_family_synthesis_result,
 )
 from .items.item_data import ALL_ITEMS
 from .items.equipment import (
@@ -98,49 +98,45 @@ def synthesize_monster(player: "Player", monster1_idx: int, monster2_idx: int, i
         else:
             return False, f"エラー: 合成結果のモンスターID '{result_monster_id}' がモンスター定義に存在しません。", None
     else:
-        family_key = None
-        if parent1.family and parent2.family:
-            family_key = tuple(sorted([parent1.family.lower(), parent2.family.lower()]))
-        if family_key and family_key in FAMILY_SYNTHESIS_RULES:
-            result_monster_id = FAMILY_SYNTHESIS_RULES[family_key]
-            if result_monster_id in ALL_MONSTERS:
-                base_new_monster_template = ALL_MONSTERS[result_monster_id]
-                new_monster = base_new_monster_template.copy()
-                if new_monster is None:
-                    return False, f"エラー: 合成結果のモンスター '{result_monster_id}' の生成に失敗しました。", None
+        result_monster_id = find_family_synthesis_result(
+            parent1.family, parent1.rank, parent2.family, parent2.rank
+        )
+        if result_monster_id and result_monster_id in ALL_MONSTERS:
+            base_new_monster_template = ALL_MONSTERS[result_monster_id]
+            new_monster = base_new_monster_template.copy()
+            if new_monster is None:
+                return False, f"エラー: 合成結果のモンスター '{result_monster_id}' の生成に失敗しました。", None
 
-                inherited_skills = []
-                for parent in (parent1, parent2):
-                    if parent.skills:
-                        skill = random.choice(parent.skills)
-                        current_names = [s.name for s in new_monster.skills + inherited_skills]
-                        if getattr(skill, "name", None) not in current_names:
-                            inherited_skills.append(copy.deepcopy(skill))
-                new_monster.skills.extend(inherited_skills)
+            inherited_skills = []
+            for parent in (parent1, parent2):
+                if parent.skills:
+                    skill = random.choice(parent.skills)
+                    current_names = [s.name for s in new_monster.skills + inherited_skills]
+                    if getattr(skill, "name", None) not in current_names:
+                        inherited_skills.append(copy.deepcopy(skill))
+            new_monster.skills.extend(inherited_skills)
 
-                avg_level = (parent1.level + parent2.level) / 2
-                hp_bonus = int(avg_level * 2)
-                atk_bonus = int(avg_level)
-                def_bonus = int(avg_level)
-                spd_bonus = int(avg_level * 0.5)
-                new_monster.max_hp += hp_bonus
-                new_monster.base_attack += atk_bonus
-                new_monster.base_defense += def_bonus
-                new_monster.base_speed += spd_bonus
-                new_monster.level = 1
-                new_monster.exp = 0
-                new_monster.hp = new_monster.max_hp
-                new_monster.is_alive = True
+            avg_level = (parent1.level + parent2.level) / 2
+            hp_bonus = int(avg_level * 2)
+            atk_bonus = int(avg_level)
+            def_bonus = int(avg_level)
+            spd_bonus = int(avg_level * 0.5)
+            new_monster.max_hp += hp_bonus
+            new_monster.base_attack += atk_bonus
+            new_monster.base_defense += def_bonus
+            new_monster.base_speed += spd_bonus
+            new_monster.level = 1
+            new_monster.exp = 0
+            new_monster.hp = new_monster.max_hp
+            new_monster.is_alive = True
 
-                indices_to_remove = sorted([monster1_idx, monster2_idx], reverse=True)
-                removed_monster_names = []
-                for idx in indices_to_remove:
-                    removed_monster_names.append(player.party_monsters.pop(idx).name)
-                player.party_monsters.append(new_monster)
-                player.monster_book.record_captured(new_monster.monster_id)
-                return True, f"{removed_monster_names[1]} と {removed_monster_names[0]} を合成して {new_monster.name} が誕生した！", new_monster
-            else:
-                return False, f"エラー: 合成結果のモンスターID '{result_monster_id}' がモンスター定義に存在しません。", None
+            indices_to_remove = sorted([monster1_idx, monster2_idx], reverse=True)
+            removed_monster_names = []
+            for idx in indices_to_remove:
+                removed_monster_names.append(player.party_monsters.pop(idx).name)
+            player.party_monsters.append(new_monster)
+            player.monster_book.record_captured(new_monster.monster_id)
+            return True, f"{removed_monster_names[1]} と {removed_monster_names[0]} を合成して {new_monster.name} が誕生した！", new_monster
 
         return False, f"{parent1.name} と {parent2.name} の組み合わせでは何も生まれなかった...", None
 

--- a/backend/tests/test_rank_family_synthesis.py
+++ b/backend/tests/test_rank_family_synthesis.py
@@ -1,0 +1,25 @@
+import unittest
+
+from monster_rpg.player import Player
+from monster_rpg.monsters.synthesis_rules import RANK_VALUES
+
+class RankFamilySynthesisTests(unittest.TestCase):
+    def test_rank_affects_family_fusion(self):
+        # Low rank parents
+        p_low = Player('Low')
+        p_low.add_monster_to_party('slime')
+        p_low.add_monster_to_party('goblin')
+        success_low, _, child_low = p_low.synthesize_monster(0, 1)
+        self.assertTrue(success_low)
+
+        # High rank parents (same families)
+        p_high = Player('High')
+        p_high.add_monster_to_party('slime')
+        p_high.add_monster_to_party('shadow_panther')
+        success_high, _, child_high = p_high.synthesize_monster(0, 1)
+        self.assertTrue(success_high)
+
+        self.assertGreater(RANK_VALUES[child_high.rank], RANK_VALUES[child_low.rank])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support dynamic monster family synthesis based on parent ranks
- expose `find_family_synthesis_result` for reuse
- update monster data helper with `get_all_monsters`
- apply new behaviour in `synthesize_monster`
- test rank influence on family synthesis

## Testing
- `pip install flask`
- `pip install flask_wtf`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8fc280888321b2b6fe5df48b5f54