### PR TITLE
Add basic enemy skills

### DIFF
--- a/backend/src/monster_rpg/skills/skills.json
+++ b/backend/src/monster_rpg/skills/skills.json
@@ -325,13 +325,23 @@
     "description": "混乱ガスで敵全体を混乱させる",
     "category": "魔法"
   },
+  "lick": {
+    "name": "なめる",
+    "power": 0,
+    "cost": 3,
+    "skill_type": "debuff",
+    "duration": 3,
+    "effects": [{"type": "buff", "stat": "defense", "amount": -1, "duration": 3}],
+    "description": "長い舌でべろりとなめる。少しだけ相手の防御力が下がる。",
+    "category": "弱体"
+  },
   "tackle": {
-    "name": "タックル",
-    "power": 15,
-    "cost": 0,
+    "name": "体当たり",
+    "power": 13,
+    "cost": 2,
     "skill_type": "attack",
-    "effects": [{"type": "damage", "amount": 15}],
-    "description": "体当たりで攻撃する",
+    "effects": [{"type": "damage"}],
+    "description": "勢いをつけて全体重を相手にぶつける。たまに外す。",
     "category": "物理"
   },
   "supersonic": {
@@ -344,13 +354,22 @@
     "category": "魔法"
   },
   "sand_attack": {
-    "name": "すなかけ",
+    "name": "土けむり",
     "power": 0,
-    "cost": 2,
+    "cost": 4,
     "skill_type": "status",
     "effects": [{"type": "status", "status": "blind"}],
-    "description": "砂をかけて目を眩ませる",
+    "description": "地面の砂や土をかけて相手の目をくらませる。命中率が下がる。",
     "category": "弱体"
+  },
+  "intimidate": {
+    "name": "威嚇する",
+    "power": 0,
+    "cost": 0,
+    "skill_type": "status",
+    "effects": [],
+    "description": "大きな声や身振りで相手を威嚇する。何も起こらない。",
+    "category": "その他"
   },
   "fireball_weak": {
     "name": "ファイアボール(弱)",

--- a/backend/tests/test_charge_release.py
+++ b/backend/tests/test_charge_release.py
@@ -18,7 +18,7 @@ class ChargeReleaseTests(unittest.TestCase):
         self.assertTrue(triggered)
         self.assertFalse(any(e['name'] == 'charging' for e in attacker.status_effects))
         self.assertEqual(attacker.defense, original_def)
-        self.assertEqual(enemy.hp, enemy.max_hp - 23)
+        self.assertEqual(enemy.hp, enemy.max_hp - 21)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add new `lick` skill and modify `tackle`
- tweak `sand_attack` and add `intimidate`
- update charge-release test for new tackle damage

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685bb1fdd1d483218971d65516166ee8