### PR TITLE
Add CSRF tokens to POST forms

### DIFF
--- a/backend/src/monster_rpg/templates/battle.html
+++ b/backend/src/monster_rpg/templates/battle.html
@@ -39,6 +39,7 @@
 
   <div class="actions">
     <form action="{{ url_for('battle', user_id=user_id) }}" method="post" style="width: 100%; display: flex; justify-content: center;">
+      {{ csrf_token() }}
       <input type="hidden" name="continue_explore" value="1">
       <button type="submit" class="btn btn-primary">探索を続ける</button>
     </form>

--- a/backend/src/monster_rpg/templates/explore.html
+++ b/backend/src/monster_rpg/templates/explore.html
@@ -53,6 +53,7 @@
     <!-- 操作ボタン -->
     <div class="action-buttons">
         <form action="{{ url_for('explore', user_id=user_id) }}" method="post" style="margin: 0;">
+          {{ csrf_token() }}
           <button class="book-btn" type="submit">さらに探索する</button>
         </form>
         <a class="book-link" href="{{ url_for('play', user_id=user_id) }}">探索をやめる</a>

--- a/backend/src/monster_rpg/templates/formation.html
+++ b/backend/src/monster_rpg/templates/formation.html
@@ -12,6 +12,7 @@
     <aside class="sidebar">
       <div class="book-page">
         <form id="formation-form" method="post" action="{{ url_for('formation', user_id=user_id) }}">
+          {{ csrf_token() }}
           <input type="hidden" name="order" id="order-input">
           <input type="hidden" name="reserve" id="reserve-input">
           <button id="confirm-btn" type="button" class="ornate-button">編成を確定</button>

--- a/backend/src/monster_rpg/templates/index.html
+++ b/backend/src/monster_rpg/templates/index.html
@@ -4,6 +4,7 @@
   <h1>モンスター合成RPG</h1>
   <div class="form-card">
     <form action="{{ url_for('auth.start_game') }}" method="post">
+      {{ csrf_token() }}
       <input name="username" placeholder="名前" required>
       <input name="password" type="password" placeholder="パスワード">
       <button type="submit">新規ゲーム</button>
@@ -11,12 +12,14 @@
   </div>
   <div class="form-card">
     <form action="{{ url_for('auth.load_existing') }}" method="post">
+      {{ csrf_token() }}
       <input name="user_id" placeholder="User ID" required>
       <button type="submit">ロード</button>
     </form>
   </div>
   <div class="form-card">
     <form action="{{ url_for('auth.login') }}" method="post">
+      {{ csrf_token() }}
       <input name="username" placeholder="ユーザー名" required>
       <input name="password" type="password" placeholder="パスワード" required>
       <button type="submit">ログイン</button>

--- a/backend/src/monster_rpg/templates/items.html
+++ b/backend/src/monster_rpg/templates/items.html
@@ -9,6 +9,7 @@
   {% set idx = loop.index0 %}
   <li>{{ item.name }}
     <form action="{{ url_for('items', user_id=user_id) }}" method="post" style="display:inline">
+      {{ csrf_token() }}
       <input type="hidden" name="item_idx" value="{{ idx }}">
       <select name="target_idx">
       {% for m in player.party_monsters %}

--- a/backend/src/monster_rpg/templates/party_manage.html
+++ b/backend/src/monster_rpg/templates/party_manage.html
@@ -13,6 +13,7 @@
     <aside class="sidebar">
       <div class="book-page">
         <form id="formation-form" method="post" action="{{ url_for('party.manage', user_id=user_id) }}">
+          {{ csrf_token() }}
           <input type="hidden" name="order" id="order-input">
           <input type="hidden" name="reserve" id="reserve-input">
           <button id="confirm-btn" type="button" class="ornate-button">編成を確定</button>

--- a/backend/src/monster_rpg/templates/play.html
+++ b/backend/src/monster_rpg/templates/play.html
@@ -24,6 +24,7 @@
             <div class="move-btn-list">
                 {% for cmd, dest, name in connections %}
                 <form action="{{ url_for('move', user_id=user_id) }}" method="post">
+                    {{ csrf_token() }}
                     <input type="hidden" name="dest" value="{{ dest }}">
                     <button type="submit" class="menu-btn"><span>{{ cmd }} → {{ name }}</span></button>
                 </form>
@@ -36,7 +37,10 @@
             <div class="menu-group">
                 <form action="{{ url_for('status', user_id=user_id) }}" method="get"><button class="menu-btn"><span>ステータス</span></button></form>
                 <form action="{{ url_for('party', user_id=user_id) }}" method="get"><button class="menu-btn"><span>パーティ</span></button></form>
-                <form action="{{ url_for('explore', user_id=user_id) }}" method="post"><button class="menu-btn"><span>たんさく</span></button></form>
+                <form action="{{ url_for('explore', user_id=user_id) }}" method="post">
+                    {{ csrf_token() }}
+                    <button class="menu-btn" type="submit"><span>たんさく</span></button>
+                </form>
                 <form action="{{ url_for('battle_log', user_id=user_id) }}" method="get"><button class="menu-btn"><span>せんとうログ</span></button></form>
                 <form action="{{ url_for('items', user_id=user_id) }}" method="get"><button class="menu-btn"><span>アイテム</span></button></form>
                 <form action="{{ url_for('synthesize', user_id=user_id) }}" method="get"><button class="menu-btn"><span>ごうせい</span></button></form>
@@ -46,9 +50,15 @@
                 <form action="{{ url_for('shop', user_id=user_id) }}" method="get"><button class="menu-btn"><span>ショップ</span></button></form>
                 {% endif %}
                 {% if loc.has_inn %}
-                <form action="{{ url_for('inn', user_id=user_id) }}" method="post"><button class="menu-btn"><span>やどや ({{ loc.inn_cost }}G)</span></button></form>
+                <form action="{{ url_for('inn', user_id=user_id) }}" method="post">
+                    {{ csrf_token() }}
+                    <button class="menu-btn" type="submit"><span>やどや ({{ loc.inn_cost }}G)</span></button>
+                </form>
                 {% endif %}
-                <form action="{{ url_for('save', user_id=user_id) }}" method="post"><button class="menu-btn save-btn"><span>セーブ</span></button></form>
+                <form action="{{ url_for('save', user_id=user_id) }}" method="post">
+                    {{ csrf_token() }}
+                    <button class="menu-btn save-btn" type="submit"><span>セーブ</span></button>
+                </form>
             </div>
         </div>
     </div>

--- a/backend/src/monster_rpg/templates/shop.html
+++ b/backend/src/monster_rpg/templates/shop.html
@@ -178,6 +178,7 @@
           <p class="product-price">{{ price }}G</p>
         </div>
         <form action="{{ url_for('shop', user_id=user_id) }}" method="post">
+          {{ csrf_token() }}
           {% if kind == 'item' %}
             <input type="hidden" name="buy_item" value="{{ obj_id }}">
           {% else %}


### PR DESCRIPTION
## Summary
- insert `{{ csrf_token() }}` in POST forms to prevent CSRF
- keep battle_turn template unchanged
- ensure tests pass

## Testing
- `pip install -q Flask Flask-WTF`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd79baa848321a3506c98cbf56309