### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 ## 起動方法
 
 ### 1. 必要なPythonパッケージのインストール
-プロジェクトのルートディレクトリ（`monster_rpg_project`）で、以下のコマンドを実行して必要なパッケージをインストールします。
+プロジェクトのルートディレクトリ（`monster_rpg_project`）で以下を実行します。
 
 ```bash
-pip install Flask
+pip install -e backend
 ```
+
+このコマンドを使わない場合は `PYTHONPATH=backend/src` を設定してください。
+必要なパッケージは `backend/requirements.txt` に記載の `Flask` と `Flask-WTF` です。
 
 ### 2. ゲームの実行
 以下のコマンドを実行してゲームを起動します。


### PR DESCRIPTION
## Summary
- adjust installation command in README
- reference Flask and Flask-WTF requirements
- mention PYTHONPATH alternative

## Testing
- `pip install -e backend`
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_686125f756e08321b5310fb30922e098