### PR TITLE
Expose Battle class via web_main

### DIFF
--- a/backend/src/monster_rpg/battle.py
+++ b/backend/src/monster_rpg/battle.py
@@ -324,6 +324,11 @@ def process_charge_state(actor: Monster, allies: list[Monster], enemies: list[Mo
 def is_party_defeated(party: list[Monster]) -> bool:
     return all(not monster.is_alive for monster in party)
 
+
+def determine_turn_order(player_party: list[Monster], enemy_party: list[Monster]) -> list[Monster]:
+    """Return monsters sorted by speed in descending order."""
+    return sorted(player_party + enemy_party, key=lambda m: m.speed, reverse=True)
+
 class Battle:
     def __init__(self, player_party: list[Monster], enemy_party: list[Monster], player: Player, log: Optional[List[Dict[str, str]]] = None, turn_order_monsters: Optional[List[Monster]] = None):
         self.player_party = player_party

--- a/backend/src/monster_rpg/web_main.py
+++ b/backend/src/monster_rpg/web_main.py
@@ -2,7 +2,8 @@
 
 from .web import create_app
 from .web.battle import active_battles
+from .battle import Battle
 
 app = create_app()
 
-__all__ = ["app", "active_battles"]
+__all__ = ["app", "active_battles", "Battle"]


### PR DESCRIPTION
## Summary
- export the `Battle` class in `monster_rpg.web_main`
- implement missing helper `determine_turn_order`

## Testing
- `pytest tests/test_turn_order.py -q`
- `pytest tests/test_battle_item_use_extended.py -k 'BattleItemMpStatusTests' -q` *(fails: AttributeError)*


------
https://chatgpt.com/codex/tasks/task_e_6861d42503008321841a0b2d35df7038