### PR TITLE
Fix stray semicolon

### DIFF
--- a/backend/src/monster_rpg/items/equipment.py
+++ b/backend/src/monster_rpg/items/equipment.py
@@ -343,7 +343,7 @@ def _choose_amount(entry: Dict[str, Any]) -> int:
         tier_weighted = []
         for tier in entry["tiers"]:
             tier_weighted.extend([tier] * tier.get("weight", 1))
-        tier_choice = random.choice(tier_weighted);
+        tier_choice = random.choice(tier_weighted)
         if "amount" in tier_choice:
             return tier_choice["amount"]
         return random.randint(tier_choice.get("min", 1), tier_choice.get("max", 1))


### PR DESCRIPTION
## Summary
- remove trailing semicolon in _choose_amount

## Testing
- `pytest -q` *(fails: 40 failed, 44 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6861d70b20b08321ac3691a2ce101530