### PR TITLE
Fix skill actions import order

### DIFF
--- a/backend/src/monster_rpg/skills/skill_actions.py
+++ b/backend/src/monster_rpg/skills/skill_actions.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 from typing import Callable, Dict, List, Optional, Any
 import random
 
+from .skills import Skill
+from ..monsters.monster_class import Monster
+
 # copied from battle to avoid circular import
 ELEMENTAL_MULTIPLIERS = {
     ("火", "風"): 1.5,
     ("風", "水"): 1.5,
     ("水", "火"): 1.5,
 }
-
-from .skills import Skill
-from ..monsters.monster_class import Monster
 
 
 def is_defending(monster: Monster) -> bool:


### PR DESCRIPTION
## Summary
- place Skill and Monster imports before any code in `skill_actions.py`

## Testing
- `make test` *(fails: 40 failed, 44 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6861d94c6adc8321aa517d2d69abeb26