### PR TITLE
Fix unused imports

### DIFF
--- a/backend/src/monster_rpg/web/utils.py
+++ b/backend/src/monster_rpg/web/utils.py
@@ -1,6 +1,5 @@
 from ..player import Player
-from ..items.equipment import Equipment, EquipmentInstance
-from ..monsters.monster_class import Monster
+from ..items.equipment import Equipment
 
 
 def process_synthesis_payload(player: Player, data: dict):


### PR DESCRIPTION
## Summary
- remove unused EquipmentInstance and Monster imports

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q backend` *(fails: award_experience() missing 1 required positional argument: 'log', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861dace28f483218cabf5fb5c1df721