### PR TITLE
Remove DB constant, use database_setup.DATABASE_NAME

### DIFF
--- a/backend/src/monster_rpg/trading.py
+++ b/backend/src/monster_rpg/trading.py
@@ -9,11 +9,9 @@ from .items.item_data import ALL_ITEMS
 from .monsters.monster_data import ALL_MONSTERS
 from .monsters.monster_class import Monster
 
-DATABASE = database_setup.DATABASE_NAME
-
 
 def _connect():
-    return sqlite3.connect(DATABASE, timeout=5)
+    return sqlite3.connect(database_setup.DATABASE_NAME, timeout=5)
 
 
 def list_item(player: Player, item_idx: int, price: int) -> bool:

--- a/backend/src/monster_rpg/webapp.py
+++ b/backend/src/monster_rpg/webapp.py
@@ -6,8 +6,6 @@ from .player import Player
 
 app = Flask(__name__)
 
-db_name = database_setup.DATABASE_NAME
-
 def get_or_create_user(username: str, password: str):
     """Return user id or an error tuple if the username already exists."""
     user_id = database_setup.get_user_id(username, password)
@@ -35,12 +33,12 @@ def new_game():
         return result
     user_id = result
     player = Player(username, user_id=user_id, gold=100)
-    player.save_game(db_name)
+    player.save_game(database_setup.DATABASE_NAME)
     return jsonify({'user_id': user_id, 'message': 'created'})
 
 @app.route('/load_game/<int:user_id>')
 def load_game(user_id):
-    player = Player.load_game(db_name, user_id=user_id)
+    player = Player.load_game(database_setup.DATABASE_NAME, user_id=user_id)
     if not player:
         return jsonify({'error': 'not found'}), 404
     return jsonify({'name': player.name, 'level': player.player_level, 'gold': player.gold})

--- a/backend/tests/test_trade.py
+++ b/backend/tests/test_trade.py
@@ -18,7 +18,6 @@ class TradeTests(unittest.TestCase):
             os.remove('monster_rpg_save.db')
         database_setup.DATABASE_NAME = self.db_path
         database_setup.initialize_database()
-        trading.DATABASE = self.db_path
         self.seller_id = database_setup.create_user('seller', 'pw1')
         self.buyer_id = database_setup.create_user('buyer', 'pw2')
         app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- drop unused DATABASE constant in `trading`
- update `_connect()` to use `database_setup.DATABASE_NAME`
- remove `db_name` indirection in `webapp`
- adjust tests to not modify removed constant

## Testing
- `PYTHONPATH=backend/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ef5fa4488321acb8dd643d60d9f5