### PR TITLE
Serialize monster skills in battle data

### DIFF
--- a/backend/tests/test_web_battle_get_json.py
+++ b/backend/tests/test_web_battle_get_json.py
@@ -39,6 +39,9 @@ class BattleGetJsonTests(unittest.TestCase):
         self.assertIn('status_effects', data['hp_values']['enemy'][0])
         self.assertIn('log', data)
         self.assertIn('finished', data)
+        self.assertIn('current_actor', data)
+        if data['current_actor']:
+            self.assertIn('skills', data['current_actor'])
 
     def test_get_returns_404_without_active_battle(self):
         active_battles.pop(self.user_id, None)

--- a/backend/tests/test_web_battle_json.py
+++ b/backend/tests/test_web_battle_json.py
@@ -39,6 +39,9 @@ class BattleViewJsonTests(unittest.TestCase):
         self.assertIn('status_effects', data['hp_values']['enemy'][0])
         self.assertIn('log', data)
         self.assertIn('finished', data)
+        self.assertIn('current_actor', data)
+        if data['current_actor']:
+            self.assertIn('skills', data['current_actor'])
 
     def test_post_accepts_json_payload(self):
         resp = self.client.post(
@@ -53,6 +56,9 @@ class BattleViewJsonTests(unittest.TestCase):
         self.assertIn('status_effects', data['hp_values']['player'][0])
         self.assertIn('log', data)
         self.assertIn('finished', data)
+        self.assertIn('current_actor', data)
+        if data['current_actor']:
+            self.assertIn('skills', data['current_actor'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- include monster skills when serializing battle state
- reconstruct skills via `ALL_SKILLS` in deserialization
- check `skills` field in battle JSON tests

## Testing
- `pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_e_686222f98eb08321be41cbede7cfb532