### PR TITLE
Fix skill button CSS class

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -467,6 +467,7 @@
             if (i !== 0) panel.classList.add('hidden');
             skills.forEach(sk => {
                 const btn = document.createElement('button');
+                btn.className = 'skill-btn';
                 btn.type = 'button';
                 btn.textContent = sk.name + (sk.cost ? ` (MP:${sk.cost})` : '');
                 const unitEl = document.querySelector(`[data-unit-id="${actor.unit_id}"]`);


### PR DESCRIPTION
## Summary
- add `skill-btn` class when building skill buttons
- keep selection highlighting using `.skill-btn.selected`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862248bb19c832192375072e97692d9