### PR TITLE
Fix CSRF for AJAX forms

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -358,6 +358,7 @@
             form.addEventListener('submit', evt => {
                 evt.preventDefault();
                 const formData = new FormData(form);
+                const csrfToken = formData.get('csrf_token');
                 const postUrl = form.getAttribute('action');  // use the form's action URL
                 const submitBtn = form.querySelector('button[type="submit"]');
                 if (submitBtn) submitBtn.disabled = true;
@@ -365,7 +366,7 @@
                 const payload = Object.fromEntries(formData.entries());
                 fetch(postUrl, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                     body: JSON.stringify(payload)
                 })
                     .then(resp => {

--- a/backend/src/monster_rpg/static/party/party.js
+++ b/backend/src/monster_rpg/static/party/party.js
@@ -6,6 +6,8 @@
 
     let equipmentList = [];
     let equipUrl = '';
+    const csrfTokenMeta = document.querySelector('meta[name="csrf-token"]');
+    const csrfToken = csrfTokenMeta ? csrfTokenMeta.getAttribute('content') : '';
     const dataElem = document.getElementById('party-data');
     if (dataElem) {
       try {
@@ -184,7 +186,7 @@
           const idx = btn.dataset.idx;
           fetch(equipUrl, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
             body: JSON.stringify({ equip_id: equipId, monster_idx: idx })
           })
           .then(res => res.json())
@@ -212,7 +214,7 @@
           const slot = btn.dataset.slot;
           fetch(equipUrl, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
             body: JSON.stringify({ equip_id: null, monster_idx: idx, slot: slot })
           })
           .then(res => res.json())

--- a/backend/src/monster_rpg/static/party/party_manage.js
+++ b/backend/src/monster_rpg/static/party/party_manage.js
@@ -4,6 +4,8 @@ window.addEventListener('DOMContentLoaded', () => {
 
   let equipmentList = [];
   let equipUrl = '';
+  const csrfTokenMeta = document.querySelector('meta[name="csrf-token"]');
+  const csrfToken = csrfTokenMeta ? csrfTokenMeta.getAttribute('content') : '';
   const dataElem = document.getElementById('party-data');
   if (dataElem) {
     try {
@@ -254,7 +256,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const idx = modal.currentMonsterData.index; // Use stored data
         fetch(equipUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
           body: JSON.stringify({ equip_id: equipId, monster_idx: idx })
         })
         .then(res => res.json())
@@ -291,7 +293,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const slot = btn.dataset.slot;
         fetch(equipUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
           body: JSON.stringify({ equip_id: null, monster_idx: idx, slot: slot })
         })
         .then(res => res.json())

--- a/backend/src/monster_rpg/templates/layout.html
+++ b/backend/src/monster_rpg/templates/layout.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>{{ title or "Monster RPG" }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
   {% block head_extra %}{% endblock %}


### PR DESCRIPTION
## Summary
- expose CSRF token via `<meta>` tag
- include CSRF token header in battle commands
- include CSRF token header in party equipment AJAX actions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686231f2480c8321a80e37372bf9da11