### PR TITLE
Fix infoBox not showing in battle view

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -48,7 +48,9 @@
         const mpPct = info.max_mp > 0 ? Math.round(info.mp / info.max_mp * 100) : 0;
         mpFill.style.width = mpPct + '%';
         mpBar.appendChild(mpFill);
+
         infoBox.appendChild(mpBar);
+        unit.appendChild(infoBox);
 
         const hpText = document.createElement('div');
         hpText.className = 'hp-text';


### PR DESCRIPTION
## Summary
- append infoBox to the battle unit element

## Testing
- `pip install -e backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686243a67c8883219007beb771d75e8f