### PR TITLE
Fix skill action serialization on battle screen

### DIFF
--- a/backend/src/monster_rpg/static/battle_turn/battle_turn.js
+++ b/backend/src/monster_rpg/static/battle_turn/battle_turn.js
@@ -369,6 +369,9 @@
                 if (submitBtn) submitBtn.disabled = true;
 
                 const payload = Object.fromEntries(formData.entries());
+                if (payload.action === 'skill' && payload.selected_skill_id) {
+                    payload.action = 'skill' + payload.selected_skill_id;
+                }
                 fetch(postUrl, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },


### PR DESCRIPTION
## Summary
- send selected skill index in the `action` field before posting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686249256f18832191f73bbc7c77e1b5