### PR TITLE
Fix logging crash in damage effect handler

### DIFF
--- a/backend/src/monster_rpg/skills/skill_actions.py
+++ b/backend/src/monster_rpg/skills/skill_actions.py
@@ -92,7 +92,8 @@ def _handle_damage(
             amount = int(context.get(amount, 0))
         else:
             amount = int(amount)
-        actual_damage = deal_damage(target, amount)
+        # pass log so damage events are recorded and no error is raised
+        actual_damage = deal_damage(target, amount, log)
         if target.hp <= 0:
             target.is_alive = False
             log.append({'type': 'info', 'message': f"{target.name} fainted!"})

--- a/backend/tests/test_damage_effect_no_skill.py
+++ b/backend/tests/test_damage_effect_no_skill.py
@@ -1,0 +1,16 @@
+import unittest
+from monster_rpg.monsters.monster_class import Monster
+from monster_rpg.skills.skill_actions import apply_effects
+
+class DamageEffectNoSkillTests(unittest.TestCase):
+    def test_damage_effect_without_skill_uses_log(self):
+        attacker = Monster('Hero', hp=50, attack=10, defense=5)
+        target = Monster('Slime', hp=30, attack=5, defense=2)
+        log = []
+        apply_effects(attacker, target, [{'type': 'damage', 'amount': 10}], None, log)
+        expected_damage = max(1, 10 - target.defense)
+        self.assertEqual(target.hp, 30 - expected_damage)
+        self.assertTrue(any('damage' in entry['message'] for entry in log))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- pass log to `deal_damage` in `_handle_damage`
- add regression test for damage effects without skills

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a54724c9848321bd6fee0edb7cc024